### PR TITLE
perf(tests): add TQ4 fixture, cache simulations, and mark slow tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,12 @@ def mse_quantizer() -> TurboQuantMSE:
 
 
 @pytest.fixture(scope="module")
+def tq4_quantizer() -> TurboQuantMSE:
+    """Module-scoped TurboQuantMSE(dim=128, bits=4)."""
+    return TurboQuantMSE(DIM, BITS_4, seed=SEED)
+
+
+@pytest.fixture(scope="module")
 def prod_quantizer() -> TurboQuantProd:
     """Module-scoped TurboQuantProd(dim=128, bits=3)."""
     return TurboQuantProd(DIM, BITS, seed=SEED)

--- a/tests/test_flash_attention_tq4.py
+++ b/tests/test_flash_attention_tq4.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from turboquant_vllm.quantizer import TurboQuantMSE
 from turboquant_vllm.triton.flash_attention import triton_flash_attention
 from turboquant_vllm.triton.flash_attention_tq4 import triton_flash_attention_tq4
 
@@ -38,21 +37,17 @@ def device():
 class TestTQ4FlashAttention:
     """Phase 2 validation: fused TQ4 FA vs unfused (decompress + vanilla FA)."""
 
-    def test_basic_mha(self, device: str) -> None:
+    def test_basic_mha(self, device: str, tq4_quantizer) -> None:
         """MHA (no GQA): fused TQ4 matches unfused path."""
         B, H, S, D = 1, 4, 32, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         # Unfused reference: decompress then vanilla FA
         expected = triton_flash_attention(q, k_decompressed, v)
@@ -62,125 +57,109 @@ class TestTQ4FlashAttention:
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Fused vs unfused cosine {cos:.6f} < 0.998"
 
-    def test_gqa_4_to_1(self, device: str) -> None:
+    def test_gqa_4_to_1(self, device: str, tq4_quantizer) -> None:
         """GQA 4:1 (Molmo2-4B config: 32Q/8KV)."""
         B, H_Q, H_KV, S, D = 1, 32, 8, 64, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"GQA 4:1 cosine {cos:.6f} < 0.998"
 
-    def test_gqa_7_to_1(self, device: str) -> None:
+    def test_gqa_7_to_1(self, device: str, tq4_quantizer) -> None:
         """GQA 7:1 (Molmo2-8B config: 28Q/4KV)."""
         B, H_Q, H_KV, S, D = 1, 28, 4, 64, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"GQA 7:1 cosine {cos:.6f} < 0.998"
 
-    def test_decode_mode(self, device: str) -> None:
+    def test_decode_mode(self, device: str, tq4_quantizer) -> None:
         """Decode: seq_q=1, long KV cache."""
         B, H_Q, H_KV, D = 1, 32, 8, 128
         S_Q, S_KV = 1, 512
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S_Q, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Decode cosine {cos:.6f} < 0.998"
 
-    def test_causal(self, device: str) -> None:
+    def test_causal(self, device: str, tq4_quantizer) -> None:
         """Causal masking with TQ4 compressed K."""
         B, H, S, D = 1, 4, 64, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v, is_causal=True)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
             is_causal=True,
         )
@@ -188,116 +167,100 @@ class TestTQ4FlashAttention:
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Causal cosine {cos:.6f} < 0.998"
 
-    def test_bf16(self, device: str) -> None:
+    def test_bf16(self, device: str, tq4_quantizer) -> None:
         """bfloat16 inputs with TQ4 compressed K."""
         B, H, S, D = 1, 4, 32, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H, S, D, device=device, dtype=torch.bfloat16)
         k = torch.randn(B, H, S, D, device=device, dtype=torch.bfloat16)
         v = torch.randn(B, H, S, D, device=device, dtype=torch.bfloat16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"bf16 cosine {cos:.6f} < 0.998"
 
-    def test_long_sequence_precision(self, device: str) -> None:
+    def test_long_sequence_precision(self, device: str, tq4_quantizer) -> None:
         """Long sequence to validate multi-tile accumulation precision."""
         B, H_Q, H_KV, S, D = 1, 32, 8, 512, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Long seq cosine {cos:.6f} < 0.998"
 
-    def test_prime_seq_length(self, device: str) -> None:
+    def test_prime_seq_length(self, device: str, tq4_quantizer) -> None:
         """Non-power-of-2 sequence length (tests masking)."""
         B, H, S, D = 1, 4, 37, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Prime seq cosine {cos:.6f} < 0.998"
 
-    def test_batched(self, device: str) -> None:
+    def test_batched(self, device: str, tq4_quantizer) -> None:
         """Multiple sequences in a batch."""
         B, H_Q, H_KV, S, D = 4, 32, 8, 64, 128
-        bits = 4
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_decompressed, v)
         actual = triton_flash_attention_tq4(
             q,
             k_packed,
             k_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             v,
         )
 

--- a/tests/test_flash_attention_tq4_kv.py
+++ b/tests/test_flash_attention_tq4_kv.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from turboquant_vllm.quantizer import TurboQuantMSE
 from turboquant_vllm.triton.flash_attention import triton_flash_attention
 from turboquant_vllm.triton.flash_attention_tq4_kv import (
     triton_flash_attention_tq4_kv,
@@ -40,22 +39,19 @@ def device():
 class TestTQ4KVFlashAttention:
     """Phase 3: fused K+V TQ4 FA vs unfused (decompress both, vanilla FA)."""
 
-    def test_basic_mha(self, device: str) -> None:
+    def test_basic_mha(self, device: str, tq4_quantizer) -> None:
         """MHA: fused K+V matches unfused path."""
-        B, H, S, D, bits = 1, 4, 32, 128, 4
+        B, H, S, D = 1, 4, 32, 128
         torch.manual_seed(42)
 
         q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec)
         actual = triton_flash_attention_tq4_kv(
@@ -64,29 +60,26 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"MHA cosine {cos:.6f} < 0.998"
 
-    def test_gqa_4_to_1(self, device: str) -> None:
+    def test_gqa_4_to_1(self, device: str, tq4_quantizer) -> None:
         """GQA 4:1 (Molmo2-4B: 32Q/8KV)."""
-        B, H_Q, H_KV, S, D, bits = 1, 32, 8, 64, 128, 4
+        B, H_Q, H_KV, S, D = 1, 32, 8, 64, 128
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec)
         actual = triton_flash_attention_tq4_kv(
@@ -95,29 +88,26 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"GQA 4:1 cosine {cos:.6f} < 0.998"
 
-    def test_gqa_7_to_1(self, device: str) -> None:
+    def test_gqa_7_to_1(self, device: str, tq4_quantizer) -> None:
         """GQA 7:1 (Molmo2-8B: 28Q/4KV)."""
-        B, H_Q, H_KV, S, D, bits = 1, 28, 4, 64, 128, 4
+        B, H_Q, H_KV, S, D = 1, 28, 4, 64, 128
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec)
         actual = triton_flash_attention_tq4_kv(
@@ -126,16 +116,16 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"GQA 7:1 cosine {cos:.6f} < 0.998"
 
-    def test_decode(self, device: str) -> None:
+    def test_decode(self, device: str, tq4_quantizer) -> None:
         """Decode: seq_q=1, long compressed KV cache."""
-        B, H_Q, H_KV, D, bits = 1, 32, 8, 128, 4
+        B, H_Q, H_KV, D = 1, 32, 8, 128
         S_Q, S_KV = 1, 512
         torch.manual_seed(42)
 
@@ -143,13 +133,10 @@ class TestTQ4KVFlashAttention:
         k = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec)
         actual = triton_flash_attention_tq4_kv(
@@ -158,29 +145,26 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Decode cosine {cos:.6f} < 0.998"
 
-    def test_causal(self, device: str) -> None:
+    def test_causal(self, device: str, tq4_quantizer) -> None:
         """Causal masking with both K and V compressed."""
-        B, H, S, D, bits = 1, 4, 64, 128, 4
+        B, H, S, D = 1, 4, 64, 128
         torch.manual_seed(42)
 
         q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec, is_causal=True)
         actual = triton_flash_attention_tq4_kv(
@@ -189,30 +173,27 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
             is_causal=True,
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Causal cosine {cos:.6f} < 0.998"
 
-    def test_long_sequence(self, device: str) -> None:
+    def test_long_sequence(self, device: str, tq4_quantizer) -> None:
         """Long sequence multi-tile accumulation precision."""
-        B, H_Q, H_KV, S, D, bits = 1, 32, 8, 512, 128, 4
+        B, H_Q, H_KV, S, D = 1, 32, 8, 512, 128
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec)
         actual = triton_flash_attention_tq4_kv(
@@ -221,29 +202,26 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
         )
 
         cos = cosine_similarity_flat(actual, expected)
         assert cos > 0.998, f"Long seq cosine {cos:.6f} < 0.998"
 
-    def test_batched(self, device: str) -> None:
+    def test_batched(self, device: str, tq4_quantizer) -> None:
         """Multiple sequences in a batch."""
-        B, H_Q, H_KV, S, D, bits = 4, 32, 8, 64, 128, 4
+        B, H_Q, H_KV, S, D = 4, 32, 8, 64, 128
         torch.manual_seed(42)
 
         q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
         k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
         v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
 
-        quantizer = TurboQuantMSE(D, bits=bits, seed=42)
-        quantizer.rotation = quantizer.rotation.to(device)
-
-        k_packed, k_norms = compress_tq4(k, quantizer)
-        v_packed, v_norms = compress_tq4(v, quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, quantizer).to(q.dtype)
+        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
+        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
         expected = triton_flash_attention(q, k_dec, v_dec)
         actual = triton_flash_attention_tq4_kv(
@@ -252,8 +230,8 @@ class TestTQ4KVFlashAttention:
             k_norms,
             v_packed,
             v_norms,
-            quantizer.codebook.centroids.to(device),
-            quantizer.rotation.to(device),
+            tq4_quantizer.codebook.centroids.to(device),
+            tq4_quantizer.rotation.to(device),
         )
 
         cos = cosine_similarity_flat(actual, expected)

--- a/tests/test_kv_cache_regression.py
+++ b/tests/test_kv_cache_regression.py
@@ -17,6 +17,7 @@ from .conftest import BITS, DIM, SEED
 
 
 @pytest.mark.unit
+@pytest.mark.slow
 class TestLongSequenceRegression:
     """Regression tests for precision at realistic sequence lengths."""
 

--- a/tests/test_per_layer_cosine.py
+++ b/tests/test_per_layer_cosine.py
@@ -9,6 +9,8 @@ Formalizes experimentally validated results from Experiments 002-005:
 
 from __future__ import annotations
 
+import functools
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -22,11 +24,12 @@ NUM_HEADS = 8
 SEQ_LEN = 128
 
 
+@functools.lru_cache(maxsize=None)
 def _per_layer_cosine(
     bits: int,
     num_layers: int = NUM_LAYERS,
     seq_len: int = SEQ_LEN,
-) -> list[float]:
+) -> tuple[float, ...]:
     """Compress random KV through multiple layers, return per-layer cosine.
 
     Args:
@@ -35,7 +38,7 @@ def _per_layer_cosine(
         seq_len: Sequence length per layer.
 
     Returns:
-        List of cosine similarities (one per layer) between original
+        Tuple of cosine similarities (one per layer) between original
         and decompressed keys.
     """
     from transformers import DynamicCache
@@ -59,7 +62,7 @@ def _per_layer_cosine(
         cos = F.cosine_similarity(original.flatten(), decompressed.flatten(), dim=0)
         cosines.append(cos.item())
 
-    return cosines
+    return tuple(cosines)
 
 
 @pytest.mark.unit
@@ -112,7 +115,73 @@ class TestPerLayerCosine:
         )
 
 
+@functools.lru_cache(maxsize=None)
+def _cached_autoregressive_decode(
+    bits: int,
+    num_layers: int = NUM_LAYERS,
+    prefill_len: int = 256,
+    gen_steps: int = 64,
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    """Simulate prefill + decode, return per-layer cosine for both phases.
+
+    Args:
+        bits: Quantization bit width.
+        num_layers: Number of transformer layers.
+        prefill_len: Tokens in prefill phase.
+        gen_steps: Number of decode steps.
+
+    Returns:
+        Tuple of (prefill_cosines, decode_cosines) per layer.
+    """
+    from transformers import DynamicCache
+
+    torch.manual_seed(42)
+    cache = DynamicCache()
+    _ = CompressedDynamicCache(cache, head_dim=DIM, bits=bits)
+
+    # Prefill
+    prefill_originals: list[torch.Tensor] = []
+    for layer_idx in range(num_layers):
+        keys = torch.randn(1, NUM_HEADS, prefill_len, DIM)
+        values = torch.randn(1, NUM_HEADS, prefill_len, DIM)
+        prefill_originals.append(keys.clone())
+        cache.update(keys, values, layer_idx=layer_idx)
+
+    prefill_cosines = []
+    for layer_idx in range(num_layers):
+        layer_keys = cache.layers[layer_idx].keys
+        assert layer_keys is not None  # populated by cache.update above
+        decompressed = layer_keys[:, :, :prefill_len, :]
+        cos = F.cosine_similarity(
+            prefill_originals[layer_idx].flatten(),
+            decompressed.flatten(),
+            dim=0,
+        )
+        prefill_cosines.append(cos.item())
+
+    # Decode — accumulate tokens one at a time
+    decode_originals: list[list[torch.Tensor]] = [[] for _ in range(num_layers)]
+    for _ in range(gen_steps):
+        for layer_idx in range(num_layers):
+            keys = torch.randn(1, NUM_HEADS, 1, DIM)
+            values = torch.randn(1, NUM_HEADS, 1, DIM)
+            decode_originals[layer_idx].append(keys.clone())
+            cache.update(keys, values, layer_idx=layer_idx)
+
+    decode_cosines = []
+    for layer_idx in range(num_layers):
+        all_orig = torch.cat(decode_originals[layer_idx], dim=2)
+        layer_keys = cache.layers[layer_idx].keys
+        assert layer_keys is not None  # populated by decode loop above
+        decompressed = layer_keys[:, :, prefill_len:, :]
+        cos = F.cosine_similarity(all_orig.flatten(), decompressed.flatten(), dim=0)
+        decode_cosines.append(cos.item())
+
+    return tuple(prefill_cosines), tuple(decode_cosines)
+
+
 @pytest.mark.unit
+@pytest.mark.slow
 class TestMultiLayerComposition:
     """Validate multi-layer composition does not degrade quality.
 
@@ -127,7 +196,7 @@ class TestMultiLayerComposition:
         num_layers: int = NUM_LAYERS,
         prefill_len: int = 256,
         gen_steps: int = 64,
-    ) -> tuple[list[float], list[float]]:
+    ) -> tuple[tuple[float, ...], tuple[float, ...]]:
         """Simulate prefill + decode, return per-layer cosine for both phases.
 
         Args:
@@ -139,51 +208,7 @@ class TestMultiLayerComposition:
         Returns:
             Tuple of (prefill_cosines, decode_cosines) per layer.
         """
-        from transformers import DynamicCache
-
-        torch.manual_seed(42)
-        cache = DynamicCache()
-        _ = CompressedDynamicCache(cache, head_dim=DIM, bits=bits)
-
-        # Prefill
-        prefill_originals: list[torch.Tensor] = []
-        for layer_idx in range(num_layers):
-            keys = torch.randn(1, NUM_HEADS, prefill_len, DIM)
-            values = torch.randn(1, NUM_HEADS, prefill_len, DIM)
-            prefill_originals.append(keys.clone())
-            cache.update(keys, values, layer_idx=layer_idx)
-
-        prefill_cosines = []
-        for layer_idx in range(num_layers):
-            layer_keys = cache.layers[layer_idx].keys
-            assert layer_keys is not None  # populated by cache.update above
-            decompressed = layer_keys[:, :, :prefill_len, :]
-            cos = F.cosine_similarity(
-                prefill_originals[layer_idx].flatten(),
-                decompressed.flatten(),
-                dim=0,
-            )
-            prefill_cosines.append(cos.item())
-
-        # Decode — accumulate tokens one at a time
-        decode_originals: list[list[torch.Tensor]] = [[] for _ in range(num_layers)]
-        for _ in range(gen_steps):
-            for layer_idx in range(num_layers):
-                keys = torch.randn(1, NUM_HEADS, 1, DIM)
-                values = torch.randn(1, NUM_HEADS, 1, DIM)
-                decode_originals[layer_idx].append(keys.clone())
-                cache.update(keys, values, layer_idx=layer_idx)
-
-        decode_cosines = []
-        for layer_idx in range(num_layers):
-            all_orig = torch.cat(decode_originals[layer_idx], dim=2)
-            layer_keys = cache.layers[layer_idx].keys
-            assert layer_keys is not None  # populated by decode loop above
-            decompressed = layer_keys[:, :, prefill_len:, :]
-            cos = F.cosine_similarity(all_orig.flatten(), decompressed.flatten(), dim=0)
-            decode_cosines.append(cos.item())
-
-        return prefill_cosines, decode_cosines
+        return _cached_autoregressive_decode(bits, num_layers, prefill_len, gen_steps)
 
     @pytest.mark.parametrize(
         ("bits", "min_cosine"),

--- a/tests/test_vllm_cache.py
+++ b/tests/test_vllm_cache.py
@@ -132,21 +132,19 @@ class TestTQ4PackedCacheRoundTrip:
     HEAD_SIZE = 128
     BLOCK_SIZE = 16
 
-    def _make_impl(self):
-        """Create a TQ4AttentionImpl without full vLLM init."""
+    def _make_impl(self, quantizer):
+        """Create a TQ4AttentionImpl without full vLLM init.
+
+        Args:
+            quantizer: TurboQuantMSE instance (from conftest tq4_quantizer fixture).
+        """
+        from turboquant_vllm.vllm.tq4_backend import TQ4_NORM_BYTES
+
         # Bypass FlashAttentionImpl.__init__ -- only init TQ4 primitives
         impl = object.__new__(TQ4AttentionImpl)
         impl.head_size = self.HEAD_SIZE
         impl.num_kv_heads = self.NUM_KV_HEADS
 
-        from turboquant_vllm.quantizer import TurboQuantMSE
-        from turboquant_vllm.vllm.tq4_backend import (
-            TQ4_BITS,
-            TQ4_NORM_BYTES,
-            TQ4_SEED,
-        )
-
-        quantizer = TurboQuantMSE(self.HEAD_SIZE, TQ4_BITS, seed=TQ4_SEED)
         impl._tq4_rotation = quantizer.rotation
         impl._tq4_centroids = quantizer.codebook.centroids
         impl._tq4_boundaries = quantizer.codebook.boundaries
@@ -168,8 +166,8 @@ class TestTQ4PackedCacheRoundTrip:
         total_bytes = self.NUM_KV_HEADS * _tq4_bytes_per_token_kv(self.HEAD_SIZE)
         return torch.zeros(num_blocks, self.BLOCK_SIZE, total_bytes, dtype=torch.uint8)
 
-    def test_compress_store_decompress_single_token(self):
-        impl = self._make_impl()
+    def test_compress_store_decompress_single_token(self, tq4_quantizer):
+        impl = self._make_impl(tq4_quantizer)
         kv_cache = self._make_cache(num_blocks=4)
 
         key = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
@@ -204,14 +202,14 @@ class TestTQ4PackedCacheRoundTrip:
         assert reconstructed_k.any(), "Decompressed K should be non-zero"
         assert reconstructed_v.any(), "Decompressed V should be non-zero"
 
-    def test_round_trip_cosine_similarity(self):
+    def test_round_trip_cosine_similarity(self, tq4_quantizer):
         """TQ4 round-trip should achieve >0.85 cosine on random data.
 
         Note: real model KV cache data achieves >0.97 cosine (validated
         in experiment 003/005).  Random Gaussian vectors give lower cosine
         because their distribution differs from actual KV activations.
         """
-        impl = self._make_impl()
+        impl = self._make_impl(tq4_quantizer)
         kv_cache = self._make_cache(num_blocks=2)
 
         key = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
@@ -234,9 +232,9 @@ class TestTQ4PackedCacheRoundTrip:
             assert cos_k > 0.85, f"K head {h} cosine {cos_k:.4f} < 0.85"
             assert cos_v > 0.85, f"V head {h} cosine {cos_v:.4f} < 0.85"
 
-    def test_multi_token_scatter_write(self):
+    def test_multi_token_scatter_write(self, tq4_quantizer):
         """Multiple tokens scattered to different slots."""
-        impl = self._make_impl()
+        impl = self._make_impl(tq4_quantizer)
         kv_cache = self._make_cache(num_blocks=4)
         N = 5
 
@@ -259,9 +257,9 @@ class TestTQ4PackedCacheRoundTrip:
                     f"Token {i} slot {slot} head {h}: K cos {cos_k:.4f}"
                 )
 
-    def test_empty_slots_decompress_to_zero(self):
+    def test_empty_slots_decompress_to_zero(self, tq4_quantizer):
         """Unwritten slots should decompress to zero."""
-        impl = self._make_impl()
+        impl = self._make_impl(tq4_quantizer)
         kv_cache = self._make_cache(num_blocks=2)
 
         # Write only slot 0
@@ -276,9 +274,9 @@ class TestTQ4PackedCacheRoundTrip:
         assert flat_k[0].any(), "Slot 0 should have data"
         assert not flat_k[1].any(), "Slot 1 should be zeros"
 
-    def test_overwrite_slot(self):
+    def test_overwrite_slot(self, tq4_quantizer):
         """Writing to the same slot twice should overwrite."""
-        impl = self._make_impl()
+        impl = self._make_impl(tq4_quantizer)
         kv_cache = self._make_cache(num_blocks=1)
 
         key1 = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
@@ -300,7 +298,7 @@ class TestTQ4PackedCacheRoundTrip:
         )
         assert cos_k2 > cos_k1, "Overwrite should match key2, not key1"
 
-    def test_cache_shape_matches_backend(self):
+    def test_cache_shape_matches_backend(self, tq4_quantizer):
         """Cache shape from backend matches what decompress expects."""
         shape = TQ4AttentionBackend.get_kv_cache_shape(
             num_blocks=10,
@@ -309,7 +307,7 @@ class TestTQ4PackedCacheRoundTrip:
             head_size=self.HEAD_SIZE,
         )
         cache = torch.zeros(*shape, dtype=torch.uint8)
-        impl = self._make_impl()
+        impl = self._make_impl(tq4_quantizer)
 
         key_cache, value_cache = impl._decompress_cache(cache, torch.float32)
         assert key_cache.shape == (
@@ -325,9 +323,9 @@ class TestTQ4PackedCacheRoundTrip:
             self.HEAD_SIZE,
         )
 
-    def test_bfloat16_output_dtype(self):
+    def test_bfloat16_output_dtype(self, tq4_quantizer):
         """Decompress can produce bf16 output."""
-        impl = self._make_impl()
+        impl = self._make_impl(tq4_quantizer)
         kv_cache = self._make_cache(num_blocks=1)
 
         key = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)

--- a/tests/test_vllm_triton_equivalence.py
+++ b/tests/test_vllm_triton_equivalence.py
@@ -24,20 +24,26 @@ class TestTritonPyTorchEquivalence:
     HEAD_DIM = 128
     NUM_KV_HEADS = 8
 
-    @pytest.fixture(autouse=True)
-    def _setup(self):
-        """Set up quantizer primitives for both paths."""
-        from turboquant_vllm.quantizer import TurboQuantMSE
-        from turboquant_vllm.vllm.tq4_backend import TQ4_BITS, TQ4_SEED
+    # Set dynamically by class-scoped _setup fixture via request.cls
+    device: torch.device
+    rotation: torch.Tensor
+    rotation_t: torch.Tensor
+    boundaries: torch.Tensor
+    centroids: torch.Tensor
+    rot_T_even: torch.Tensor
+    rot_T_odd: torch.Tensor
 
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        quantizer = TurboQuantMSE(self.HEAD_DIM, TQ4_BITS, seed=TQ4_SEED)
-        self.rotation = quantizer.rotation.to(self.device)
-        self.rotation_t = self.rotation.T.contiguous()
-        self.boundaries = quantizer.codebook.boundaries.to(self.device)
-        self.centroids = quantizer.codebook.centroids.to(self.device)
-        self.rot_T_even = self.rotation_t[:, 0::2].contiguous()
-        self.rot_T_odd = self.rotation_t[:, 1::2].contiguous()
+    @pytest.fixture(autouse=True, scope="class")
+    def _setup(self, request, tq4_quantizer):
+        """Set up quantizer primitives for both paths (once per class)."""
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        request.cls.device = device
+        request.cls.rotation = tq4_quantizer.rotation.to(device)
+        request.cls.rotation_t = request.cls.rotation.T.contiguous()
+        request.cls.boundaries = tq4_quantizer.codebook.boundaries.to(device)
+        request.cls.centroids = tq4_quantizer.codebook.centroids.to(device)
+        request.cls.rot_T_even = request.cls.rotation_t[:, 0::2].contiguous()
+        request.cls.rot_T_odd = request.cls.rotation_t[:, 1::2].contiguous()
 
     # --- helpers: old PyTorch path ---
 


### PR DESCRIPTION
TEA test quality review scored performance at 0/100 — ~32 redundant `TurboQuantMSE(bits=4)` constructions each triggered a ~2s scipy Lloyd-Max solve, and expensive multi-layer simulations repeated identically across test methods. There was no way to skip slow tests during development.

- Add module-scoped `tq4_quantizer` fixture to `conftest.py` and refactor 4 test files to use it, eliminating ~32 per-test quantizer constructions
- Cache `_per_layer_cosine()` and `_simulate_autoregressive_decode()` with `@functools.lru_cache` to avoid redundant 36-layer simulations
- Add `@pytest.mark.slow` to `TestLongSequenceRegression` and `TestMultiLayerComposition` so `pytest -m 'not slow'` skips them during iteration

Test: `uv run pytest` (all 155 tests pass); `uv run pytest -m 'not slow' --collect-only` confirms slow classes excluded

Closes #8

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `test_vllm_triton_equivalence.py`: `_setup` fixture changed from function to class scope using `request.cls` — verify no test method mutates shared tensors
- `test_per_layer_cosine.py`: extracted `_cached_autoregressive_decode` module-level function — verify `lru_cache` key correctness with default args

### Related
- Predecessor: refactor(tests): split oversized files and consolidate duplicated helpers (#12)
- Spec: `_bmad-output/implementation-artifacts/spec-gh-8-test-perf.md`