### PR TITLE
refactor(ci): refine ty overrides with replace-imports-with-any and exclude experiments/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,11 +109,12 @@ min-coverage = 100.0
 
 [tool.ty.src]
 include = ["src", "tests"]
+exclude = ["experiments"]
 
 [[tool.ty.overrides]]
 include = ["src/turboquant_vllm/vllm/**", "tests/test_vllm_*.py"]
-rules.unresolved-import = "ignore"
 rules.unknown-argument = "ignore"
+analysis.replace-imports-with-any = ["vllm.**"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
The `[[tool.ty.overrides]]` config blanket-suppressed all unresolved imports in vllm integration files via `rules.unresolved-import = "ignore"`, which also hid real bugs from non-vllm packages. The `experiments/` directory was not excluded from ty despite being excluded from docvet and coverage, causing false-positive type errors from intentional monkey-patching.

- Replace `rules.unresolved-import = "ignore"` with `analysis.replace-imports-with-any = ["vllm.**"]` for surgical suppression — non-vllm import errors in override files are now visible
- Add `experiments/` to `[tool.ty.src] exclude` to match existing docvet (`extend-exclude`) and coverage (`omit`) boundaries
- Keep `rules.unknown-argument = "ignore"` for vllm decorator/JIT patterns

Test: `uv run ty check src tests` — exits 0, all checks passed

Closes #10

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Verify `analysis.replace-imports-with-any` is the correct ty override key (ty is alpha, API may shift)
- The `"vllm.**"` double-star glob is intentional — single `*` only matches one module level, missing deep imports like `vllm.v1.attention.backends.flash_attn`
- Three `# ty: ignore` comments in `tq4_backend.py` are now unused (warnings, not errors) — deferred to follow-up to keep this PR config-only

### Related
- Party mode research session validated `replace-imports-with-any` approach over the original `src.exclude` proposal
- Deferred: remove unused `ty: ignore` comments in `tq4_backend.py:483,490,561`