### PR TITLE
chore(lint): remove dead type-ignore comments from excluded directories

### DIFF
--- a/experiments/experiment_007_e2e_amd_validation.py
+++ b/experiments/experiment_007_e2e_amd_validation.py
@@ -246,14 +246,14 @@ def step_3_3_gpu_compressed(
         wrapper = CompressedDynamicCache(self_cache, head_dim=head_dim, bits=bits)
         wrappers.append(wrapper)
 
-    DynamicCache.__init__ = patched_init  # type: ignore[method-assign]
+    DynamicCache.__init__ = patched_init
 
     try:
         result = _run_inference(
             model, processor, prompt, max_new_tokens, f"GPU-TQ{bits}"
         )
     finally:
-        DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = original_init
 
     if wrappers:
         stats = wrappers[-1].compression_stats()

--- a/experiments/experiment_010_fused_tq4_kv_e2e.py
+++ b/experiments/experiment_010_fused_tq4_kv_e2e.py
@@ -271,7 +271,7 @@ def run_experiment(
             w = CompressedDynamicCache(self_cache, head_dim=head_dim, bits=bits)
             wrappers.append(w)
 
-        DynamicCache.__init__ = patched_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = patched_init
         try:
             unfused = _run_inference(
                 model,
@@ -282,7 +282,7 @@ def run_experiment(
                 image,
             )
         finally:
-            DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+            DynamicCache.__init__ = original_init
 
         # Path 3: Fused TQ4 K+V (cache side-channel)
         fused_wrappers: list[CompressedDynamicCache] = []
@@ -298,7 +298,7 @@ def run_experiment(
             fused_wrappers.append(w)
             install_fused_tq4_kv(model, w)
 
-        DynamicCache.__init__ = fused_patched_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = fused_patched_init
         try:
             fused = _run_inference(
                 model,
@@ -309,7 +309,7 @@ def run_experiment(
                 image,
             )
         finally:
-            DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+            DynamicCache.__init__ = original_init
             uninstall_fused_tq4_kv(model)
 
         # Comparisons

--- a/experiments/experiment_011_molmo2_8b_tq4_validation.py
+++ b/experiments/experiment_011_molmo2_8b_tq4_validation.py
@@ -240,13 +240,13 @@ def run_experiment(
                 CompressedDynamicCache(self_cache, head_dim=head_dim, bits=bits)
             )
 
-        DynamicCache.__init__ = patched_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = patched_init
         try:
             tq4 = _run_inference(
                 model, processor, prompt, max_new_tokens, f"{label}-TQ4", image
             )
         finally:
-            DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+            DynamicCache.__init__ = original_init
 
         # Compare
         b_ids = sdpa["output_token_ids"]

--- a/experiments/experiment_012_turboquantprod_quality.py
+++ b/experiments/experiment_012_turboquantprod_quality.py
@@ -173,13 +173,13 @@ def run_experiment(
             CompressedDynamicCache(self_cache, head_dim=head_dim, bits=bits)
         )
 
-    DynamicCache.__init__ = mse_patched_init  # type: ignore[method-assign]
+    DynamicCache.__init__ = mse_patched_init
     try:
         mse_result = _run_inference(
             model, processor, prompt, max_new_tokens, "TQ-MSE-4bit"
         )
     finally:
-        DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = original_init
     results["tq_mse"] = mse_result
 
     # Path 3: TurboQuantProd 4-bit with estimate_inner_product
@@ -314,7 +314,7 @@ def run_experiment(
 
         # Diagnostic: compare estimated vs reference scores at layer 0
         if layer_idx == 0 and not hasattr(prod_attention_forward, "_diag_done"):
-            prod_attention_forward._diag_done = True  # type: ignore[attr-defined]
+            prod_attention_forward._diag_done = True
             # Reference: standard Q @ K^T * scaling
             key_expanded = key.repeat_interleave(n_groups, dim=1)
             ref_scores = torch.matmul(query, key_expanded.transpose(2, 3)).float()
@@ -355,14 +355,14 @@ def run_experiment(
 
     # Patch DynamicCache to use prod_cache_update
     original_init_update = DynamicCache.update
-    DynamicCache.update = prod_cache_update  # type: ignore[assignment]
+    DynamicCache.update = prod_cache_update
 
     try:
         prod_result = _run_inference(
             model, processor, prompt, max_new_tokens, "TQ-Prod-4bit"
         )
     finally:
-        DynamicCache.update = original_init_update  # type: ignore[assignment]
+        DynamicCache.update = original_init_update
         model.config._attn_implementation = original_impl
         prod_keys.clear()
 

--- a/experiments/experiment_013_fp32_eager_baseline.py
+++ b/experiments/experiment_013_fp32_eager_baseline.py
@@ -279,7 +279,7 @@ def run_experiment(
             fused_wrappers.append(w)
             install_fused_tq4_kv(model_ref[0], w)
 
-        DynamicCache.__init__ = fused_patched_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = fused_patched_init
         try:
             path_results["fused_tq4"] = _run_inference(
                 model,
@@ -290,7 +290,7 @@ def run_experiment(
                 image,
             )
         finally:
-            DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+            DynamicCache.__init__ = original_init
             uninstall_fused_tq4_kv(model)
         del model
         torch.cuda.empty_cache()

--- a/experiments/experiment_014_full_episode_benchmark.py
+++ b/experiments/experiment_014_full_episode_benchmark.py
@@ -347,7 +347,7 @@ def _run_tq4(
         w = CompressedDynamicCache(self_cache, head_dim=head_dim, bits=4)
         last_wrapper[0] = w
 
-    DynamicCache.__init__ = patched_init  # type: ignore[method-assign]
+    DynamicCache.__init__ = patched_init
 
     results: dict[str, Any] = {
         "clips": [],
@@ -415,7 +415,7 @@ def _run_tq4(
                 f"{vram_peak:.0f} MiB"
             )
     finally:
-        DynamicCache.__init__ = original_init  # type: ignore[method-assign]
+        DynamicCache.__init__ = original_init
         del model
         torch.cuda.empty_cache()
 

--- a/src/turboquant_vllm/vllm/tq4_backend.py
+++ b/src/turboquant_vllm/vllm/tq4_backend.py
@@ -480,14 +480,14 @@ class TQ4AttentionImpl(FlashAttentionImpl):
             max_seqlen_k=attn_metadata.max_seq_len,
             softmax_scale=self.scale,
             causal=attn_metadata.causal,
-            alibi_slopes=self.alibi_slopes,  # ty: ignore[invalid-argument-type]
+            alibi_slopes=self.alibi_slopes,
             window_size=list(self.sliding_window)
             if self.sliding_window is not None
             else None,
             block_table=attn_metadata.block_table,
             softcap=self.logits_soft_cap,
             scheduler_metadata=attn_metadata.scheduler_metadata,
-            fa_version=self.vllm_flash_attn_version,  # ty: ignore[invalid-argument-type]
+            fa_version=self.vllm_flash_attn_version,
             q_descale=q_descale,
             k_descale=k_descale,
             v_descale=v_descale,
@@ -558,5 +558,5 @@ def register_tq4_backend() -> None:
             return TQ4FullAttentionSpec(**kwargs)
         return spec
 
-    Attention.get_kv_cache_spec = _tq4_get_kv_cache_spec  # ty: ignore[invalid-assignment]
+    Attention.get_kv_cache_spec = _tq4_get_kv_cache_spec
     logger.info("TQ4 attention backend registered as CUSTOM (packed cache)")


### PR DESCRIPTION
Inline `# ty: ignore` and `# type: ignore` comments in ty-excluded/overridden directories suppressed errors that no tool raises anymore. They add noise and mislead future readers into thinking a real type conflict exists.

- Remove 3 `# ty: ignore` from `vllm/tq4_backend.py` (dead due to `replace-imports-with-any` override)
- Remove 17 `# type: ignore` across 6 experiment files (ty excludes `experiments/` entirely)
- Retain `# noqa: D102` on `tq4_backend.py:89` — ruff still enforces D102 on this file
- Retain `# noqa: PLW0603` on `tq4_backend.py:530` — intentional global statement

Test: `uv run ty check src tests && uv run ruff check .`

Closes #11

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Pure comment removal — zero runtime behavior change. Verify the `# noqa: D102` retention is correct (ruff checks `vllm/` even though docvet doesn't).

### Related
- Issue spec correction: `# noqa: D102` on line 89 is load-bearing for ruff, not dead as originally assumed