### PR TITLE
test(flash-attention): parametrize boilerplate tests on shape tuples

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ instances to eliminate redundant computation and ensure reproducibility.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -148,3 +150,48 @@ def decompress_tq4(
     flat_norms = norms.reshape(-1, 1)
     reconstructed = quantizer.dequantize(flat_idx, flat_norms)
     return reconstructed.reshape(B, H, S, D)
+
+
+def assert_tq4_fused_matches_unfused(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v_ref: torch.Tensor,
+    tq4_quantizer: TurboQuantMSE,
+    device: str,
+    fused_fn: Callable[..., torch.Tensor],
+    is_causal: bool = False,
+    threshold: float = 0.998,
+) -> None:
+    """Assert a fused TQ4 FA kernel matches the unfused decompress-then-FA path.
+
+    Handles K compression/decompression internally.  The caller supplies
+    ``v_ref`` (raw V for K-only kernels, decompressed V for K+V kernels) and
+    a ``fused_fn`` closure that captures any V-side compressed artifacts it
+    needs.
+
+    Args:
+        q: Query tensor ``[B, H_Q, S_Q, D]``.
+        k: Key tensor ``[B, H_KV, S_KV, D]``.
+        v_ref: Value tensor for the unfused reference path (raw or
+            pre-decompressed).
+        tq4_quantizer: Configured TurboQuantMSE instance.
+        device: Device string (``"cuda"``).
+        fused_fn: ``(q, k_packed, k_norms, centroids, rotation, is_causal)
+            -> Tensor``.  For K+V kernels the closure captures ``v_packed``
+            and ``v_norms`` from the caller's scope.
+        is_causal: Whether to apply causal masking.
+        threshold: Minimum cosine similarity between fused and unfused outputs.
+    """
+    from turboquant_vllm.triton.flash_attention import triton_flash_attention
+
+    k_packed, k_norms = compress_tq4(k, tq4_quantizer)
+    k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
+    centroids = tq4_quantizer.codebook.centroids.to(device)
+    rotation = tq4_quantizer.rotation.to(device)
+
+    expected = triton_flash_attention(q, k_dec, v_ref, is_causal=is_causal)
+    actual = fused_fn(q, k_packed, k_norms, centroids, rotation, is_causal)
+
+    cos = cosine_similarity_flat(actual, expected)
+    assert cos > threshold, f"Fused vs unfused cosine {cos:.6f} < {threshold}"

--- a/tests/test_flash_attention_tq4.py
+++ b/tests/test_flash_attention_tq4.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 import pytest
 import torch
 
-from turboquant_vllm.triton.flash_attention import triton_flash_attention
 from turboquant_vllm.triton.flash_attention_tq4 import triton_flash_attention_tq4
 
-from .conftest import compress_tq4, cosine_similarity_flat, decompress_tq4
+from .conftest import assert_tq4_fused_matches_unfused
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -30,6 +29,23 @@ def device():
 
 
 # ---------------------------------------------------------------------------
+# Shape matrix: (B, H_Q, H_KV, S_Q, S_KV, D, is_causal, dtype)
+# ---------------------------------------------------------------------------
+
+TQ4_SHAPES = [
+    pytest.param(1, 4, 4, 32, 32, 128, False, torch.float16, id="mha_basic"),
+    pytest.param(1, 32, 8, 64, 64, 128, False, torch.float16, id="gqa_4to1"),
+    pytest.param(1, 28, 4, 64, 64, 128, False, torch.float16, id="gqa_7to1"),
+    pytest.param(1, 32, 8, 1, 512, 128, False, torch.float16, id="decode"),
+    pytest.param(1, 4, 4, 64, 64, 128, True, torch.float16, id="causal"),
+    pytest.param(1, 4, 4, 32, 32, 128, False, torch.bfloat16, id="bf16"),
+    pytest.param(1, 32, 8, 512, 512, 128, False, torch.float16, id="long_seq"),
+    pytest.param(1, 4, 4, 37, 37, 128, False, torch.float16, id="prime_seq"),
+    pytest.param(4, 32, 8, 64, 64, 128, False, torch.float16, id="batched"),
+]
+
+
+# ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
@@ -38,223 +54,45 @@ def device():
 class TestTQ4FlashAttention:
     """Phase 2 validation: fused TQ4 FA vs unfused (decompress + vanilla FA)."""
 
-    def test_basic_mha(self, device: str, tq4_quantizer) -> None:
-        """MHA (no GQA): fused TQ4 matches unfused path."""
-        B, H, S, D = 1, 4, 32, 128
+    @pytest.mark.parametrize(
+        ("B", "H_Q", "H_KV", "S_Q", "S_KV", "D", "is_causal", "dtype"),
+        TQ4_SHAPES,
+    )
+    def test_fused_matches_unfused(
+        self,
+        device: str,
+        tq4_quantizer,
+        B: int,
+        H_Q: int,
+        H_KV: int,
+        S_Q: int,
+        S_KV: int,
+        D: int,
+        is_causal: bool,
+        dtype: torch.dtype,
+    ) -> None:
+        """Fused TQ4 FA matches unfused path for given shape configuration."""
+        q = torch.randn(B, H_Q, S_Q, D, device=device, dtype=dtype)
+        k = torch.randn(B, H_KV, S_KV, D, device=device, dtype=dtype)
+        v = torch.randn(B, H_KV, S_KV, D, device=device, dtype=dtype)
 
-        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
+        def _fused(q, k_packed, k_norms, centroids, rotation, is_causal):
+            return triton_flash_attention_tq4(
+                q,
+                k_packed,
+                k_norms,
+                centroids,
+                rotation,
+                v,
+                is_causal=is_causal,
+            )
 
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        # Unfused reference: decompress then vanilla FA
-        expected = triton_flash_attention(q, k_decompressed, v)
-
-        # Fused: TQ4 decompression inside kernel
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
+        assert_tq4_fused_matches_unfused(
+            q=q,
+            k=k,
+            v_ref=v,
+            tq4_quantizer=tq4_quantizer,
+            device=device,
+            fused_fn=_fused,
+            is_causal=is_causal,
         )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Fused vs unfused cosine {cos:.6f} < 0.998"
-
-    def test_gqa_4_to_1(self, device: str, tq4_quantizer) -> None:
-        """GQA 4:1 (Molmo2-4B config: 32Q/8KV)."""
-        B, H_Q, H_KV, S, D = 1, 32, 8, 64, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"GQA 4:1 cosine {cos:.6f} < 0.998"
-
-    def test_gqa_7_to_1(self, device: str, tq4_quantizer) -> None:
-        """GQA 7:1 (Molmo2-8B config: 28Q/4KV)."""
-        B, H_Q, H_KV, S, D = 1, 28, 4, 64, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"GQA 7:1 cosine {cos:.6f} < 0.998"
-
-    def test_decode_mode(self, device: str, tq4_quantizer) -> None:
-        """Decode: seq_q=1, long KV cache."""
-        B, H_Q, H_KV, D = 1, 32, 8, 128
-        S_Q, S_KV = 1, 512
-
-        q = torch.randn(B, H_Q, S_Q, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Decode cosine {cos:.6f} < 0.998"
-
-    def test_causal(self, device: str, tq4_quantizer) -> None:
-        """Causal masking with TQ4 compressed K."""
-        B, H, S, D = 1, 4, 64, 128
-
-        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v, is_causal=True)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-            is_causal=True,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Causal cosine {cos:.6f} < 0.998"
-
-    def test_bf16(self, device: str, tq4_quantizer) -> None:
-        """bfloat16 inputs with TQ4 compressed K."""
-        B, H, S, D = 1, 4, 32, 128
-
-        q = torch.randn(B, H, S, D, device=device, dtype=torch.bfloat16)
-        k = torch.randn(B, H, S, D, device=device, dtype=torch.bfloat16)
-        v = torch.randn(B, H, S, D, device=device, dtype=torch.bfloat16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"bf16 cosine {cos:.6f} < 0.998"
-
-    def test_long_sequence_precision(self, device: str, tq4_quantizer) -> None:
-        """Long sequence to validate multi-tile accumulation precision."""
-        B, H_Q, H_KV, S, D = 1, 32, 8, 512, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Long seq cosine {cos:.6f} < 0.998"
-
-    def test_prime_seq_length(self, device: str, tq4_quantizer) -> None:
-        """Non-power-of-2 sequence length (tests masking)."""
-        B, H, S, D = 1, 4, 37, 128
-
-        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Prime seq cosine {cos:.6f} < 0.998"
-
-    def test_batched(self, device: str, tq4_quantizer) -> None:
-        """Multiple sequences in a batch."""
-        B, H_Q, H_KV, S, D = 4, 32, 8, 64, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        k_decompressed = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_decompressed, v)
-        actual = triton_flash_attention_tq4(
-            q,
-            k_packed,
-            k_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            v,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Batched cosine {cos:.6f} < 0.998"

--- a/tests/test_flash_attention_tq4_kv.py
+++ b/tests/test_flash_attention_tq4_kv.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 import pytest
 import torch
 
-from turboquant_vllm.triton.flash_attention import triton_flash_attention
 from turboquant_vllm.triton.flash_attention_tq4_kv import (
     triton_flash_attention_tq4_kv,
 )
 
-from .conftest import compress_tq4, cosine_similarity_flat, decompress_tq4
+from .conftest import (
+    assert_tq4_fused_matches_unfused,
+    compress_tq4,
+    decompress_tq4,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -32,6 +35,21 @@ def device():
 
 
 # ---------------------------------------------------------------------------
+# Shape matrix: (B, H_Q, H_KV, S_Q, S_KV, D, is_causal, dtype)
+# ---------------------------------------------------------------------------
+
+TQ4_KV_SHAPES = [
+    pytest.param(1, 4, 4, 32, 32, 128, False, torch.float16, id="mha_basic"),
+    pytest.param(1, 32, 8, 64, 64, 128, False, torch.float16, id="gqa_4to1"),
+    pytest.param(1, 28, 4, 64, 64, 128, False, torch.float16, id="gqa_7to1"),
+    pytest.param(1, 32, 8, 1, 512, 128, False, torch.float16, id="decode"),
+    pytest.param(1, 4, 4, 64, 64, 128, True, torch.float16, id="causal"),
+    pytest.param(1, 32, 8, 512, 512, 128, False, torch.float16, id="long_seq"),
+    pytest.param(4, 32, 8, 64, 64, 128, False, torch.float16, id="batched"),
+]
+
+
+# ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
@@ -40,193 +58,49 @@ def device():
 class TestTQ4KVFlashAttention:
     """Phase 3: fused K+V TQ4 FA vs unfused (decompress both, vanilla FA)."""
 
-    def test_basic_mha(self, device: str, tq4_quantizer) -> None:
-        """MHA: fused K+V matches unfused path."""
-        B, H, S, D = 1, 4, 32, 128
+    @pytest.mark.parametrize(
+        ("B", "H_Q", "H_KV", "S_Q", "S_KV", "D", "is_causal", "dtype"),
+        TQ4_KV_SHAPES,
+    )
+    def test_fused_kv_matches_unfused(
+        self,
+        device: str,
+        tq4_quantizer,
+        B: int,
+        H_Q: int,
+        H_KV: int,
+        S_Q: int,
+        S_KV: int,
+        D: int,
+        is_causal: bool,
+        dtype: torch.dtype,
+    ) -> None:
+        """Fused K+V TQ4 FA matches unfused path for given shape configuration."""
+        q = torch.randn(B, H_Q, S_Q, D, device=device, dtype=dtype)
+        k = torch.randn(B, H_KV, S_KV, D, device=device, dtype=dtype)
+        v = torch.randn(B, H_KV, S_KV, D, device=device, dtype=dtype)
 
-        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
         v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
         v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
 
-        expected = triton_flash_attention(q, k_dec, v_dec)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
+        def _fused(q, k_packed, k_norms, centroids, rotation, is_causal):
+            return triton_flash_attention_tq4_kv(
+                q,
+                k_packed,
+                k_norms,
+                v_packed,
+                v_norms,
+                centroids,
+                rotation,
+                is_causal=is_causal,
+            )
+
+        assert_tq4_fused_matches_unfused(
+            q=q,
+            k=k,
+            v_ref=v_dec,
+            tq4_quantizer=tq4_quantizer,
+            device=device,
+            fused_fn=_fused,
+            is_causal=is_causal,
         )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"MHA cosine {cos:.6f} < 0.998"
-
-    def test_gqa_4_to_1(self, device: str, tq4_quantizer) -> None:
-        """GQA 4:1 (Molmo2-4B: 32Q/8KV)."""
-        B, H_Q, H_KV, S, D = 1, 32, 8, 64, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_dec, v_dec)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"GQA 4:1 cosine {cos:.6f} < 0.998"
-
-    def test_gqa_7_to_1(self, device: str, tq4_quantizer) -> None:
-        """GQA 7:1 (Molmo2-8B: 28Q/4KV)."""
-        B, H_Q, H_KV, S, D = 1, 28, 4, 64, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_dec, v_dec)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"GQA 7:1 cosine {cos:.6f} < 0.998"
-
-    def test_decode(self, device: str, tq4_quantizer) -> None:
-        """Decode: seq_q=1, long compressed KV cache."""
-        B, H_Q, H_KV, D = 1, 32, 8, 128
-        S_Q, S_KV = 1, 512
-
-        q = torch.randn(B, H_Q, S_Q, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S_KV, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_dec, v_dec)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Decode cosine {cos:.6f} < 0.998"
-
-    def test_causal(self, device: str, tq4_quantizer) -> None:
-        """Causal masking with both K and V compressed."""
-        B, H, S, D = 1, 4, 64, 128
-
-        q = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_dec, v_dec, is_causal=True)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-            is_causal=True,
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Causal cosine {cos:.6f} < 0.998"
-
-    def test_long_sequence(self, device: str, tq4_quantizer) -> None:
-        """Long sequence multi-tile accumulation precision."""
-        B, H_Q, H_KV, S, D = 1, 32, 8, 512, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_dec, v_dec)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Long seq cosine {cos:.6f} < 0.998"
-
-    def test_batched(self, device: str, tq4_quantizer) -> None:
-        """Multiple sequences in a batch."""
-        B, H_Q, H_KV, S, D = 4, 32, 8, 64, 128
-
-        q = torch.randn(B, H_Q, S, D, device=device, dtype=torch.float16)
-        k = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-        v = torch.randn(B, H_KV, S, D, device=device, dtype=torch.float16)
-
-        k_packed, k_norms = compress_tq4(k, tq4_quantizer)
-        v_packed, v_norms = compress_tq4(v, tq4_quantizer)
-        k_dec = decompress_tq4(k_packed, k_norms, tq4_quantizer).to(q.dtype)
-        v_dec = decompress_tq4(v_packed, v_norms, tq4_quantizer).to(q.dtype)
-
-        expected = triton_flash_attention(q, k_dec, v_dec)
-        actual = triton_flash_attention_tq4_kv(
-            q,
-            k_packed,
-            k_norms,
-            v_packed,
-            v_norms,
-            tq4_quantizer.codebook.centroids.to(device),
-            tq4_quantizer.rotation.to(device),
-        )
-
-        cos = cosine_similarity_flat(actual, expected)
-        assert cos > 0.998, f"Batched cosine {cos:.6f} < 0.998"


### PR DESCRIPTION
9 tests in `TestTQ4FlashAttention` and 7 in `TestTQ4KVFlashAttention` each repeated 10-15 lines of identical compress/decompress/compare boilerplate, differing only in shape tuple, `is_causal`, and `dtype`. This was the last HIGH severity TEA test quality finding.

- Extract shared `assert_tq4_fused_matches_unfused()` helper into `tests/conftest.py` — owns K compression, unfused reference call, fused closure call, and cosine assertion
- Collapse 9 K-only test methods into single parametrized test with `TQ4_SHAPES` (8-tuples with explicit `pytest.param` IDs)
- Collapse 7 K+V test methods into single parametrized test with `TQ4_KV_SHAPES` (decoupled shape list)
- Net reduction: 241 lines deleted across 3 files

Test: `uv run pytest tests/test_flash_attention_tq4.py tests/test_flash_attention_tq4_kv.py --collect-only -q` (16 items collected)

Closes #16

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Helper design: `v_ref` parameter lets K-only pass raw V while K+V passes decompressed V; `fused_fn` closure captures kernel-specific args
- Shape tuple fidelity: each parametrize entry maps 1:1 to an original test method's dimensions

### Related
- #16 (issue with design decision comment)