### PR TITLE
test(regression): add model regression test architecture and verify GPU smoke test

### DIFF
--- a/tests/test_model_regression.py
+++ b/tests/test_model_regression.py
@@ -97,7 +97,7 @@ def test_model_regression(model_id: str) -> None:
                     ref_v.flatten().float(), comp_v.flatten().float(), dim=0
                 ).item()
                 layer_cos = min(k_cos, v_cos)
-                assert layer_cos > COMPRESSION_QUALITY_THRESHOLD, (
+                assert layer_cos >= COMPRESSION_QUALITY_THRESHOLD, (
                     f"Layer {layer_idx}: cosine {layer_cos:.6f} < {COMPRESSION_QUALITY_THRESHOLD}"
                 )
     finally:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -362,9 +362,11 @@ class TestVerifyGPU:
         """End-to-end verification of Molmo2-4B on real GPU."""
         # 0.99 = compression quality tier for random Gaussian data at 4-bit
         # (verify.py's default 0.999 is cache parity tier — wrong for this comparison)
-        result = _run_verification("allenai/Molmo2-4B", bits=4, threshold=0.99)
-        assert result["status"] == "PASS"
-        assert result["min_cosine"] > 0.99
-        assert result["validation"] == "VALIDATED"
-        gc.collect()
-        torch.cuda.empty_cache()
+        try:
+            result = _run_verification("allenai/Molmo2-4B", bits=4, threshold=0.99)
+            assert result["status"] == "PASS"
+            assert result["min_cosine"] >= 0.99
+            assert result["validation"] == "VALIDATED"
+        finally:
+            gc.collect()
+            torch.cuda.empty_cache()


### PR DESCRIPTION
Pre-release regression testing had no automated way to validate compression quality
across supported model families. GPU code paths in verify.py were also untested on
real hardware.

- Add `tests/test_model_regression.py` with parametrized compress-decompress-cosine
  validation per model (starts with Molmo2-4B, extensible via REGRESSION_MODELS list)
- Add `TestVerifyGPU` class to `tests/test_verify.py` exercising `_run_verification`
  end-to-end on real GPU hardware
- Use `COMPRESSION_QUALITY_THRESHOLD = 0.99` (compression quality tier per architecture
  doc — quantized vs uncompressed comparison, not cache parity)
- Include proper VRAM cleanup with try/finally, gc.collect(), and empty_cache()

Test: `uv run pytest tests/test_model_regression.py -v` (requires CUDA)

fix(test): add gc.collect() before cuda empty_cache in verify GPU test

Accelerate dispatch hooks create cyclic references — gc.collect() needed before
empty_cache() to reclaim VRAM, matching test_model_regression.py cleanup pattern.

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Threshold set to 0.99 (compression quality tier), not 0.999 (cache parity) — justified by architecture doc tier definitions; the test compares quantized vs uncompressed
- Pre-release command: `uv run pytest tests/test_model_regression.py -v`

### Related
- Story 2.2 in Epic 2 (Multi-Model Validation & Diagnostics)
- Consumes context manager from Epic 1 (CompressedDynamicCache)
- Architecture Decision 4 (Multi-Model Test Architecture)