### PR TITLE
test(regression): validate Mistral 7B compression quality

### DIFF
--- a/src/turboquant_vllm/verify.py
+++ b/src/turboquant_vllm/verify.py
@@ -4,13 +4,16 @@ Runs a 128-token random Gaussian prefill through CompressedDynamicCache and
 reports per-layer cosine similarity vs uncompressed DynamicCache. Outputs
 PASS/FAIL against a configurable threshold (default 0.999, cache parity tier).
 
+Validated model families (Molmo2, Mistral) report ``"validation": "VALIDATED"``
+in the output; unvalidated models report ``"UNVALIDATED"`` as a warning.
+
 Usage:
     ```bash
     # Human-readable summary to stdout
     python -m turboquant_vllm.verify --model allenai/Molmo2-4B --bits 4
 
     # JSON to stdout, human summary to stderr (pipe-friendly)
-    python -m turboquant_vllm.verify --model allenai/Molmo2-4B --bits 4 --json
+    python -m turboquant_vllm.verify --model mistralai/Mistral-7B-v0.1 --bits 4 --json
     ```
 
 Examples:
@@ -37,6 +40,7 @@ from typing import Any
 # Llama and Mistral are added by stories 2.3 and 2.4 respectively.
 VALIDATED_MODELS: dict[str, str] = {
     "molmo2": "Molmo2",
+    "mistral": "Mistral",
 }
 
 CACHE_PARITY_THRESHOLD = 0.999  # cache parity tier
@@ -44,6 +48,9 @@ CACHE_PARITY_THRESHOLD = 0.999  # cache parity tier
 
 def _detect_model_config(model: Any) -> dict[str, int]:
     """Extract KV cache parameters from a model's config.
+
+    Handles both VLMs (``text_config`` wrapper) and text-only models.
+    Falls back to ``hidden_size // num_heads`` when ``head_dim`` is ``None``.
 
     Args:
         model: A loaded HuggingFace model.
@@ -56,7 +63,7 @@ def _detect_model_config(model: Any) -> dict[str, int]:
     text_config = getattr(config, "text_config", config)
     hidden_size = text_config.hidden_size
     num_heads = text_config.num_attention_heads
-    head_dim = getattr(text_config, "head_dim", hidden_size // num_heads)
+    head_dim = getattr(text_config, "head_dim", None) or hidden_size // num_heads
     num_kv_heads = getattr(text_config, "num_key_value_heads", num_heads)
     num_layers = text_config.num_hidden_layers
     return {

--- a/tests/test_model_regression.py
+++ b/tests/test_model_regression.py
@@ -27,6 +27,7 @@ COMPRESSION_QUALITY_THRESHOLD = 0.99  # compression quality tier -- see architec
 
 REGRESSION_MODELS = [
     pytest.param("allenai/Molmo2-4B", id="molmo2-4b"),
+    pytest.param("mistralai/Mistral-7B-v0.1", id="mistral-7b"),
 ]
 
 
@@ -57,10 +58,8 @@ def test_model_regression(model_id: str) -> None:
 
     try:
         text_config = getattr(config, "text_config", config)
-        head_dim = getattr(
-            text_config,
-            "head_dim",
-            text_config.hidden_size // text_config.num_attention_heads,
+        head_dim = getattr(text_config, "head_dim", None) or (
+            text_config.hidden_size // text_config.num_attention_heads
         )
         num_kv_heads = getattr(
             text_config, "num_key_value_heads", text_config.num_attention_heads

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -244,9 +244,13 @@ class TestValidatedModels:
         assert "molmo2" in VALIDATED_MODELS
         assert VALIDATED_MODELS["molmo2"] == "Molmo2"
 
+    def test_mistral_exact_match(self):
+        assert "mistral" in VALIDATED_MODELS
+        assert VALIDATED_MODELS["mistral"] == "Mistral"
+
     def test_unvalidated_for_unknown_type(self):
+        assert "gpt2" not in VALIDATED_MODELS
         assert "llama" not in VALIDATED_MODELS
-        assert "mistral" not in VALIDATED_MODELS
 
     def test_no_substring_match(self):
         # "molmo2" should not match "molmo2-extended" or "xmolmo2"

--- a/tests/test_vllm_triton_equivalence.py
+++ b/tests/test_vllm_triton_equivalence.py
@@ -50,10 +50,10 @@ class TestTritonPyTorchEquivalence:
         """Set up quantizer primitives for both paths (once per class)."""
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         request.cls.device = device
-        request.cls.rotation = tq4_quantizer.rotation.to(device)
+        request.cls.rotation = tq4_quantizer.rotation.to(device).clone()
         request.cls.rotation_t = request.cls.rotation.T.contiguous()
-        request.cls.boundaries = tq4_quantizer.codebook.boundaries.to(device)
-        request.cls.centroids = tq4_quantizer.codebook.centroids.to(device)
+        request.cls.boundaries = tq4_quantizer.codebook.boundaries.to(device).clone()
+        request.cls.centroids = tq4_quantizer.codebook.centroids.to(device).clone()
         request.cls.rot_T_even = request.cls.rotation_t[:, 0::2].contiguous()
         request.cls.rot_T_odd = request.cls.rotation_t[:, 1::2].contiguous()
 


### PR DESCRIPTION
Mistral 7B (`mistralai/Mistral-7B-v0.1`) was the second text-only model family validated for KV cache compression. All 32 layers passed with cosine >= 0.9951 against the 0.99 compression quality threshold, confirming architecture-independence across GQA models (Molmo2, Mistral). During validation, a pre-existing bug was discovered: `config.head_dim` is explicitly `None` on Mistral, causing the `getattr` fallback to be bypassed.

- Add `"mistral": "Mistral"` to `VALIDATED_MODELS` in `verify.py`
- Add `pytest.param("mistralai/Mistral-7B-v0.1", id="mistral-7b")` to `REGRESSION_MODELS`
- Fix `head_dim` detection to handle explicit `None` via `or` fallback in `verify.py` and `test_model_regression.py`
- Update `test_verify.py` stale negative assertion and add `test_mistral_exact_match`
- Add defensive `.clone()` to 3 shared tensor refs in `test_vllm_triton_equivalence.py` (test maturity MEDIUM 3)

Test: `uv run pytest -m "not gpu"` — 121 pass, 3 skipped (vLLM not installed). GPU: `uv run pytest tests/test_model_regression.py -k mistral` — pass.

fix(verify): handle explicit None head_dim in _detect_model_config

- `getattr(config, "head_dim", fallback)` returns `None` when attribute exists but value is None (Mistral 7B)
- Apply `or` fallback pattern in both `verify.py` and `test_model_regression.py`

chore(test): add .clone() to shared tensor refs in triton equivalence tests

- Resolves test-review.md MEDIUM 3: defend against future in-place mutation of module-scoped quantizer tensors

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
The `head_dim` fix changes semantics: `getattr(..., None) or fallback` treats a falsy `head_dim` (e.g., `0`) differently than the old `getattr(..., fallback)`. This is correct — no real model has `head_dim=0` — but reviewers should confirm. Note: `benchmark.py` has the same old pattern but was out of scope (tracked in issue 29).

### Related
- Closes #29 scope upstream — `benchmark.py` has the same bug (separate fix)
- Structurally identical to story 2.3 (Llama 3.1 8B validation)