### PR TITLE
test(regression): cache regression simulation via module-level lru_cache

### DIFF
--- a/tests/test_kv_cache_regression.py
+++ b/tests/test_kv_cache_regression.py
@@ -7,13 +7,66 @@ fp16 norms issue) that don't manifest in short-sequence unit tests.
 
 from __future__ import annotations
 
+import functools
+
 import pytest
 import torch
 import torch.nn.functional as F
 
 from turboquant_vllm.kv_cache import CompressedDynamicCache, TurboQuantKVCache
 
-from .conftest import BITS, DIM, SEED
+from .conftest import BITS, DIM
+
+_NUM_LAYERS = 36
+_NUM_HEADS = 8
+_PREFILL_LEN = 1024
+_GEN_STEPS = 32
+
+_WRAPPER_CLS_MAP: dict[str, type] = {
+    "TurboQuantKVCache": TurboQuantKVCache,
+    "CompressedDynamicCache": CompressedDynamicCache,
+}
+
+
+@functools.lru_cache(maxsize=None)
+def _cached_regression_run(
+    cls_name: str,
+    bits: int,
+) -> tuple[torch.Tensor, ...]:
+    """Run prefill + generation simulation, cached by (cls_name, bits).
+
+    Args:
+        cls_name: Name of wrapper class (key into ``_WRAPPER_CLS_MAP``).
+        bits: Quantization bit width.
+
+    Returns:
+        Tuple of decompressed key tensors (one per layer) for the final
+        generation step.
+    """
+    from transformers import DynamicCache
+
+    torch.manual_seed(42)
+
+    wrapper_cls = _WRAPPER_CLS_MAP[cls_name]
+    cache = DynamicCache()
+    _ = wrapper_cls(cache, head_dim=DIM, bits=bits)
+
+    for layer_idx in range(_NUM_LAYERS):
+        k = torch.randn(1, _NUM_HEADS, _PREFILL_LEN, DIM)
+        v = torch.randn(1, _NUM_HEADS, _PREFILL_LEN, DIM)
+        cache.update(k, v, layer_idx=layer_idx)
+
+    final_keys: list[torch.Tensor] = []
+    for step in range(_GEN_STEPS):
+        step_keys = []
+        for layer_idx in range(_NUM_LAYERS):
+            k = torch.randn(1, _NUM_HEADS, 1, DIM)
+            v = torch.randn(1, _NUM_HEADS, 1, DIM)
+            out_k, _ = cache.update(k, v, layer_idx=layer_idx)
+            step_keys.append(out_k)
+        final_keys = step_keys
+
+    return tuple(final_keys)
 
 
 @pytest.mark.unit
@@ -21,10 +74,10 @@ from .conftest import BITS, DIM, SEED
 class TestLongSequenceRegression:
     """Regression tests for precision at realistic sequence lengths."""
 
-    NUM_LAYERS = 36
-    NUM_HEADS = 8
-    PREFILL_LEN = 1024
-    GEN_STEPS = 32
+    NUM_LAYERS = _NUM_LAYERS
+    NUM_HEADS = _NUM_HEADS
+    PREFILL_LEN = _PREFILL_LEN
+    GEN_STEPS = _GEN_STEPS
 
     def _run_prefill_and_generate(
         self,
@@ -41,29 +94,7 @@ class TestLongSequenceRegression:
             List of decompressed key tensors (one per layer) after
             prefill + generation steps, for the final generation step.
         """
-        from transformers import DynamicCache
-
-        cache = DynamicCache()
-        _ = wrapper_cls(cache, head_dim=DIM, bits=bits)
-
-        # Prefill: push PREFILL_LEN tokens through all layers
-        for layer_idx in range(self.NUM_LAYERS):
-            k = torch.randn(1, self.NUM_HEADS, self.PREFILL_LEN, DIM)
-            v = torch.randn(1, self.NUM_HEADS, self.PREFILL_LEN, DIM)
-            cache.update(k, v, layer_idx=layer_idx)
-
-        # Generation: push 1 token at a time through all layers
-        final_keys: list[torch.Tensor] = []
-        for step in range(self.GEN_STEPS):
-            step_keys = []
-            for layer_idx in range(self.NUM_LAYERS):
-                k = torch.randn(1, self.NUM_HEADS, 1, DIM)
-                v = torch.randn(1, self.NUM_HEADS, 1, DIM)
-                out_k, _ = cache.update(k, v, layer_idx=layer_idx)
-                step_keys.append(out_k)
-            final_keys = step_keys
-
-        return final_keys
+        return list(_cached_regression_run(wrapper_cls.__name__, bits))
 
     def test_compressed_matches_accuracy_only(self) -> None:
         """CompressedDynamicCache should closely match TurboQuantKVCache.
@@ -74,10 +105,7 @@ class TestLongSequenceRegression:
         nearly identical. A cosine similarity below 0.999 per layer
         would indicate a precision regression.
         """
-        torch.manual_seed(SEED)
         keys_accuracy = self._run_prefill_and_generate(TurboQuantKVCache)
-
-        torch.manual_seed(SEED)
         keys_compressed = self._run_prefill_and_generate(CompressedDynamicCache)
 
         assert len(keys_accuracy) == self.NUM_LAYERS
@@ -98,7 +126,6 @@ class TestLongSequenceRegression:
 
     def test_no_nan_or_inf_at_scale(self) -> None:
         """No NaN or Inf should appear after many layers and tokens."""
-        torch.manual_seed(SEED)
         keys = self._run_prefill_and_generate(CompressedDynamicCache)
 
         for layer_idx, k in enumerate(keys):
@@ -155,12 +182,22 @@ class TestLongSequenceRegression:
         # At 36 layers × 8 heads × 1024 tokens, savings should be substantial
         assert stats["savings_mib"] > 50
 
+    def test_cache_hits_for_regression_run(self) -> None:
+        """Verify _cached_regression_run produces cache hits across tests."""
+        _cached_regression_run.cache_clear()
+        self._run_prefill_and_generate(TurboQuantKVCache)
+        self._run_prefill_and_generate(CompressedDynamicCache)
+        # Second call with same args should hit cache
+        self._run_prefill_and_generate(TurboQuantKVCache)
+        info = _cached_regression_run.cache_info()
+        assert info.hits > 0, (
+            f"Expected cache hits but got {info.hits} "
+            f"(misses={info.misses}, size={info.currsize})"
+        )
+
     def test_4bit_nibble_at_scale(self) -> None:
         """TQ4 nibble-packed should work at 36 layers with 1024 tokens."""
-        torch.manual_seed(SEED)
         keys_accuracy = self._run_prefill_and_generate(TurboQuantKVCache, bits=4)
-
-        torch.manual_seed(SEED)
         keys_compressed = self._run_prefill_and_generate(CompressedDynamicCache, bits=4)
 
         for layer_idx in range(self.NUM_LAYERS):


### PR DESCRIPTION
The regression test suite re-ran expensive 36-layer prefill+generate simulations
on every test method call, even when multiple tests consumed identical results.
This caches the simulation at module level, matching the established pattern from
`test_per_layer_cosine.py`.

- Extract `_run_prefill_and_generate` body into `_cached_regression_run()` with `@functools.lru_cache(maxsize=None)`
- Convert `wrapper_cls` to hashable `cls_name: str` key via `_WRAPPER_CLS_MAP`
- Add `test_cache_hits_for_regression_run` to verify caching works
- Remove redundant `torch.manual_seed(SEED)` calls (cached function seeds internally)

Test: `uv run pytest tests/test_kv_cache_regression.py -v`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Verify `_WRAPPER_CLS_MAP` correctly maps both wrapper classes
- Confirm `torch.manual_seed(42)` inside cached function matches `_cached_autoregressive_decode` pattern
- Check that removing explicit seeding from test methods doesn't change behavior (cached function handles it)

### Related
- Story 6.1 test maturity requirement (Priority 7 from test-review.md)
- Pattern reference: `tests/test_per_layer_cosine.py` lines 29-66, 119-181