### PR TITLE
feat(triton): add out parameter to tq4 compress/decompress wrappers

### DIFF
--- a/src/turboquant_vllm/triton/tq4_compress.py
+++ b/src/turboquant_vllm/triton/tq4_compress.py
@@ -140,6 +140,7 @@ def tq4_compress(
     rotation_T_even: torch.Tensor,
     rotation_T_odd: torch.Tensor,
     boundaries: torch.Tensor,
+    out: tuple[torch.Tensor, torch.Tensor] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Compress vectors to TQ4 nibble-packed format.
 
@@ -152,6 +153,9 @@ def tq4_compress(
             ``rotation.T``, pre-split for contiguous loads.
         rotation_T_odd: ``(D, D//2)`` fp32 -- odd columns.
         boundaries: ``(N_BOUND,)`` fp32 quantization boundaries.
+        out: Optional pre-allocated ``(packed, norms)`` buffers.  When
+            provided, results are written into these tensors and the same
+            objects are returned.  Follows PyTorch ``out`` convention.
 
     Returns:
         Tuple of ``(packed, norms)`` where packed is ``(N, H, D//2)``
@@ -162,11 +166,14 @@ def tq4_compress(
     M = N * H
 
     if not x.is_cuda:
-        return _tq4_compress_cpu(x, rotation_T_even, rotation_T_odd, boundaries)
+        return _tq4_compress_cpu(x, rotation_T_even, rotation_T_odd, boundaries, out)
 
     x_flat = x.reshape(M, D).contiguous()
-    packed = torch.empty(M, HALF_D, dtype=torch.uint8, device=x.device)
-    norms = torch.empty(M, dtype=torch.float32, device=x.device)
+    if out is not None:
+        packed, norms = out
+    else:
+        packed = torch.empty(M, HALF_D, dtype=torch.uint8, device=x.device)
+        norms = torch.empty(M, dtype=torch.float32, device=x.device)
 
     N_BOUND = boundaries.shape[0]
     BLOCK_K = min(32, D)
@@ -186,6 +193,8 @@ def tq4_compress(
         BLOCK_K=BLOCK_K,  # ty: ignore[invalid-argument-type]
     )
 
+    if out is not None:
+        return packed, norms
     return packed.reshape(N, H, HALF_D), norms.reshape(N, H, 1)
 
 
@@ -194,6 +203,7 @@ def _tq4_compress_cpu(
     rotation_T_even: torch.Tensor,
     rotation_T_odd: torch.Tensor,
     boundaries: torch.Tensor,
+    out: tuple[torch.Tensor, torch.Tensor] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Pure PyTorch fallback for CPU tensors.
 
@@ -202,16 +212,18 @@ def _tq4_compress_cpu(
         rotation_T_even: ``(D, D//2)`` fp32 even cols of rotation.T.
         rotation_T_odd: ``(D, D//2)`` fp32 odd cols of rotation.T.
         boundaries: ``(N_BOUND,)`` fp32 boundaries.
+        out: Optional pre-allocated ``(packed, norms)`` buffers.
 
     Returns:
         Tuple of ``(packed, norms)`` — same shapes as Triton path.
     """
     N, H, D = x.shape
     HALF_D = D // 2
-    flat = x.reshape(N * H, D).float()
+    M = N * H
+    flat = x.reshape(M, D).float()
 
-    norms = torch.norm(flat, dim=-1, keepdim=True)
-    normalized = flat / (norms + 1e-10)
+    raw_norms = torch.norm(flat, dim=-1, keepdim=True)
+    normalized = flat / (raw_norms + 1e-10)
 
     # Reconstruct full rotation.T from even/odd halves
     rotation_T = torch.empty(D, D, dtype=torch.float32, device=x.device)
@@ -223,6 +235,14 @@ def _tq4_compress_cpu(
     indices = indices.clamp(0, 2**4 - 1)
 
     idx_u8 = indices.to(torch.uint8)
-    packed = (idx_u8[:, 0::2] << 4) | idx_u8[:, 1::2]
+    raw_packed = (idx_u8[:, 0::2] << 4) | idx_u8[:, 1::2]
 
-    return packed.reshape(N, H, HALF_D), norms.reshape(N, H, 1)
+    packed_out = raw_packed.reshape(N, H, HALF_D)
+    norms_out = raw_norms.reshape(N, H, 1)
+
+    if out is not None:
+        out[0].copy_(packed_out)
+        out[1].copy_(norms_out)
+        return out
+
+    return packed_out, norms_out

--- a/src/turboquant_vllm/triton/tq4_decompress.py
+++ b/src/turboquant_vllm/triton/tq4_decompress.py
@@ -102,6 +102,7 @@ def tq4_decompress(
     norms: torch.Tensor,
     centroids: torch.Tensor,
     dtype: torch.dtype = torch.float16,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Decompress TQ4 nibble-packed data to full-precision vectors.
 
@@ -114,6 +115,9 @@ def tq4_decompress(
         norms: ``(N, H, 1)`` fp32 -- per-vector norms.
         centroids: ``(C,)`` fp32 -- centroid table (C=16 for TQ4).
         dtype: Output dtype (default: ``torch.float16``).
+        out: Optional pre-allocated ``(N, H, D)`` output tensor.  When
+            provided, results are written into it and the same tensor is
+            returned.  Follows PyTorch ``out`` convention.
 
     Returns:
         Tensor of shape ``(N, H, D)`` in ``dtype``, still in rotated
@@ -125,13 +129,15 @@ def tq4_decompress(
 
     # CPU fallback: PyTorch path (Triton requires CUDA)
     if not packed.is_cuda:
-        return _tq4_decompress_cpu(packed, norms, centroids, dtype)
+        return _tq4_decompress_cpu(packed, norms, centroids, dtype, out)
 
     # Flatten to 2D for the kernel
     packed_flat = packed.reshape(M, half_D).contiguous()
     norms_flat = norms.reshape(M).contiguous()
 
-    out = torch.empty(M, D, dtype=dtype, device=packed.device)
+    caller_out = out
+    if out is None:
+        out = torch.empty(M, D, dtype=dtype, device=packed.device)
 
     grid = (M,)
     _tq4_decompress_kernel[grid](
@@ -143,6 +149,8 @@ def tq4_decompress(
         HALF_D=half_D,  # ty: ignore[invalid-argument-type]
     )
 
+    if caller_out is not None:
+        return caller_out
     return out.reshape(N, H, D)
 
 
@@ -151,6 +159,7 @@ def _tq4_decompress_cpu(
     norms: torch.Tensor,
     centroids: torch.Tensor,
     dtype: torch.dtype,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Pure PyTorch fallback for CPU tensors (no rotation).
 
@@ -159,6 +168,7 @@ def _tq4_decompress_cpu(
         norms: ``(N, H, 1)`` fp32.
         centroids: ``(C,)`` fp32.
         dtype: Output dtype.
+        out: Optional pre-allocated output tensor.
 
     Returns:
         Tensor ``(N, H, D)`` in ``dtype``, rotated space.
@@ -170,5 +180,9 @@ def _tq4_decompress_cpu(
     indices = torch.stack([high, low], dim=-1).reshape(N * H, D)
     flat_norms = norms.reshape(N * H, 1)
     reconstructed = centroids[indices]
-    result = reconstructed * flat_norms
-    return result.reshape(N, H, D).to(dtype)
+    result = (reconstructed * flat_norms).reshape(N, H, D).to(dtype)
+
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -22,7 +22,7 @@ from .conftest import cosine_similarity_flat
 
 
 @pytest.fixture()
-def device():
+def device() -> str:
     """CUDA-only device fixture (overrides conftest parametrized fixture)."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for Triton Flash Attention")

--- a/tests/test_flash_attention_tq4.py
+++ b/tests/test_flash_attention_tq4.py
@@ -21,7 +21,7 @@ from .conftest import assert_tq4_fused_matches_unfused
 
 
 @pytest.fixture()
-def device():
+def device() -> str:
     """CUDA-only device fixture (overrides conftest parametrized fixture)."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for Triton Flash Attention")

--- a/tests/test_flash_attention_tq4_kv.py
+++ b/tests/test_flash_attention_tq4_kv.py
@@ -27,7 +27,7 @@ from .conftest import (
 
 
 @pytest.fixture()
-def device():
+def device() -> str:
     """CUDA-only device fixture (overrides conftest parametrized fixture)."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for Triton Flash Attention")

--- a/tests/test_tq4_out_parameter.py
+++ b/tests/test_tq4_out_parameter.py
@@ -1,0 +1,220 @@
+"""Tests for the ``out`` parameter on tq4_compress and tq4_decompress.
+
+Validates the PyTorch ``out`` convention: when a pre-allocated buffer is
+provided, results are written into it and the *same tensor object* is
+returned.  Tests run on CPU (pure PyTorch fallback) unconditionally —
+no vLLM or CUDA required.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from turboquant_vllm.quantizer import TurboQuantMSE
+from turboquant_vllm.triton.tq4_compress import tq4_compress
+from turboquant_vllm.triton.tq4_decompress import tq4_decompress
+
+pytestmark = [pytest.mark.unit]
+
+# Dimensions matching project defaults (DIM=128, BITS_4=4 from conftest)
+N, H, D = 2, 4, 128
+HALF_D = D // 2
+
+
+@pytest.fixture(scope="module")
+def compress_args(tq4_quantizer: TurboQuantMSE) -> dict[str, torch.Tensor]:
+    """Rotation halves and boundaries for tq4_compress (CPU)."""
+    rotation_t = tq4_quantizer.rotation.T.contiguous()
+    return {
+        "rotation_T_even": rotation_t[:, 0::2].contiguous(),
+        "rotation_T_odd": rotation_t[:, 1::2].contiguous(),
+        "boundaries": tq4_quantizer.codebook.boundaries.clone(),
+    }
+
+
+@pytest.fixture(scope="module")
+def centroids(tq4_quantizer: TurboQuantMSE) -> torch.Tensor:
+    """Centroid table for tq4_decompress (CPU)."""
+    return tq4_quantizer.codebook.centroids.clone()
+
+
+def _make_input(n: int = N, h: int = H, d: int = D) -> torch.Tensor:
+    """Random fp32 input on CPU."""
+    return torch.randn(n, h, d)
+
+
+# ── tq4_compress ────────────────────────────────────────────────────
+
+
+class TestTq4CompressOut:
+    """Out-parameter contract for tq4_compress."""
+
+    def test_backward_compat_no_out(self, compress_args: dict) -> None:
+        """Calling without out behaves identically to before."""
+        x = _make_input()
+        packed, norms = tq4_compress(x, **compress_args)
+        assert packed.shape == (N, H, HALF_D)
+        assert norms.shape == (N, H, 1)
+        assert packed.dtype == torch.uint8
+        assert norms.dtype == torch.float32
+
+    def test_out_identity(self, compress_args: dict) -> None:
+        """Returned tensors are the same objects as the provided buffers."""
+        x = _make_input()
+        packed_buf = torch.empty(N, H, HALF_D, dtype=torch.uint8)
+        norms_buf = torch.empty(N, H, 1, dtype=torch.float32)
+
+        result = tq4_compress(x, **compress_args, out=(packed_buf, norms_buf))
+
+        assert result[0] is packed_buf
+        assert result[1] is norms_buf
+
+    def test_out_numerical_equivalence(self, compress_args: dict) -> None:
+        """Results with out are identical to results without out."""
+        x = _make_input()
+        ref_packed, ref_norms = tq4_compress(x, **compress_args)
+
+        packed_buf = torch.empty(N, H, HALF_D, dtype=torch.uint8)
+        norms_buf = torch.empty(N, H, 1, dtype=torch.float32)
+        out_packed, out_norms = tq4_compress(
+            x, **compress_args, out=(packed_buf, norms_buf)
+        )
+
+        assert torch.equal(out_packed, ref_packed)
+        assert torch.equal(out_norms, ref_norms)
+
+    def test_out_buffer_reuse(self, compress_args: dict) -> None:
+        """Calling twice with the same buffers overwrites correctly."""
+        packed_buf = torch.empty(N, H, HALF_D, dtype=torch.uint8)
+        norms_buf = torch.empty(N, H, 1, dtype=torch.float32)
+        out = (packed_buf, norms_buf)
+
+        x1 = _make_input()
+        tq4_compress(x1, **compress_args, out=out)
+        snap1_packed = packed_buf.clone()
+
+        x2 = _make_input()
+        tq4_compress(x2, **compress_args, out=out)
+
+        ref_packed, _ = tq4_compress(x2, **compress_args)
+        assert torch.equal(packed_buf, ref_packed)
+        assert not torch.equal(snap1_packed, packed_buf)
+
+    def test_out_multi_token_batch(self, compress_args: dict) -> None:
+        """Out parameter works with N>1 batch (validates reshape logic)."""
+        n = 4
+        x = _make_input(n=n)
+        packed_buf = torch.empty(n, H, HALF_D, dtype=torch.uint8)
+        norms_buf = torch.empty(n, H, 1, dtype=torch.float32)
+
+        result = tq4_compress(x, **compress_args, out=(packed_buf, norms_buf))
+        ref_packed, ref_norms = tq4_compress(x, **compress_args)
+
+        assert result[0] is packed_buf
+        assert torch.equal(result[0], ref_packed)
+        assert torch.equal(result[1], ref_norms)
+
+
+# ── tq4_decompress ──────────────────────────────────────────────────
+
+
+class TestTq4DecompressOut:
+    """Out-parameter contract for tq4_decompress."""
+
+    def test_backward_compat_no_out(
+        self,
+        compress_args: dict,
+        centroids: torch.Tensor,
+    ) -> None:
+        """Calling without out behaves identically to before."""
+        x = _make_input()
+        packed, norms = tq4_compress(x, **compress_args)
+        result = tq4_decompress(packed, norms, centroids, dtype=torch.float32)
+        assert result.shape == (N, H, D)
+        assert result.dtype == torch.float32
+
+    def test_out_identity(
+        self,
+        compress_args: dict,
+        centroids: torch.Tensor,
+    ) -> None:
+        """Returned tensor is the same object as the provided buffer."""
+        x = _make_input()
+        packed, norms = tq4_compress(x, **compress_args)
+        out_buf = torch.empty(N, H, D, dtype=torch.float32)
+
+        result = tq4_decompress(
+            packed,
+            norms,
+            centroids,
+            dtype=torch.float32,
+            out=out_buf,
+        )
+
+        assert result is out_buf
+
+    def test_out_numerical_equivalence(
+        self,
+        compress_args: dict,
+        centroids: torch.Tensor,
+    ) -> None:
+        """Results with out are identical to results without out."""
+        x = _make_input()
+        packed, norms = tq4_compress(x, **compress_args)
+
+        ref = tq4_decompress(packed, norms, centroids, dtype=torch.float32)
+        out_buf = torch.empty(N, H, D, dtype=torch.float32)
+        out_result = tq4_decompress(
+            packed,
+            norms,
+            centroids,
+            dtype=torch.float32,
+            out=out_buf,
+        )
+
+        assert torch.equal(out_result, ref)
+
+    def test_out_buffer_reuse(
+        self,
+        compress_args: dict,
+        centroids: torch.Tensor,
+    ) -> None:
+        """Calling twice with the same buffer overwrites correctly."""
+        out_buf = torch.empty(N, H, D, dtype=torch.float32)
+
+        x1 = _make_input()
+        packed1, norms1 = tq4_compress(x1, **compress_args)
+        tq4_decompress(packed1, norms1, centroids, dtype=torch.float32, out=out_buf)
+        snap1 = out_buf.clone()
+
+        x2 = _make_input()
+        packed2, norms2 = tq4_compress(x2, **compress_args)
+        tq4_decompress(packed2, norms2, centroids, dtype=torch.float32, out=out_buf)
+
+        ref = tq4_decompress(packed2, norms2, centroids, dtype=torch.float32)
+        assert torch.equal(out_buf, ref)
+        assert not torch.equal(snap1, out_buf)
+
+    def test_out_multi_token_batch(
+        self,
+        compress_args: dict,
+        centroids: torch.Tensor,
+    ) -> None:
+        """Out parameter works with N>1 batch."""
+        n = 4
+        x = _make_input(n=n)
+        packed, norms = tq4_compress(x, **compress_args)
+        out_buf = torch.empty(n, H, D, dtype=torch.float32)
+
+        result = tq4_decompress(
+            packed,
+            norms,
+            centroids,
+            dtype=torch.float32,
+            out=out_buf,
+        )
+        ref = tq4_decompress(packed, norms, centroids, dtype=torch.float32)
+
+        assert result is out_buf
+        assert torch.equal(result, ref)


### PR DESCRIPTION
The vLLM decode path needs to eliminate dynamic memory allocation for CUDA graph compatibility. Previously, `tq4_compress()` and `tq4_decompress()` always allocated fresh output tensors internally, which breaks CUDA graph capture.

- Add optional `out` parameter to `tq4_compress()` and `tq4_decompress()` Python wrappers following PyTorch `out` convention
- When `out` is provided, write results into pre-allocated buffers and return the same tensor objects; when omitted, allocate internally (backward compatible)
- Apply same pattern to CPU fallback paths (`_tq4_compress_cpu`, `_tq4_decompress_cpu`)
- Add 10 CPU-only unit tests covering backward compat, identity, numerical equivalence, buffer reuse, and multi-token batch for both compress and decompress

Test: `uv run pytest -m "not gpu" -k test_tq4_out_parameter -v`

test(flash-attention): add return type annotations to device fixtures

- Add `-> str` return type annotation to `device` fixture in `test_flash_attention.py`, `test_flash_attention_tq4.py`, and `test_flash_attention_tq4_kv.py`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
GPU path passes caller-provided 3D `out` buffers directly to Triton kernels using flat pointer arithmetic. This is correct for contiguous tensors (the CUDA graph use case) since `(N, H, D)` contiguous shares the same memory layout as `(M, D)`. No shape/dtype validation is performed, following PyTorch `out` convention.

### Related
Story 4.1 (Epic 4: CUDA Graph Compatibility). Foundation for Story 4.2 which will use these `out` parameters with pre-allocated buffers in `TQ4AttentionImpl`.