### PR TITLE
feat(vllm): add CUDA graph buffer pre-allocation to TQ4 backend

### DIFF
--- a/src/turboquant_vllm/vllm/tq4_backend.py
+++ b/src/turboquant_vllm/vllm/tq4_backend.py
@@ -40,7 +40,11 @@ from turboquant_vllm.triton.tq4_compress import tq4_compress
 from turboquant_vllm.triton.tq4_decompress import tq4_decompress
 
 if TYPE_CHECKING:
-    from vllm.v1.attention.backend import AttentionImplBase, AttentionMetadataBuilder
+    from vllm.v1.attention.backend import (
+        AttentionCGSupport,
+        AttentionImplBase,
+        AttentionMetadataBuilder,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +103,26 @@ class TQ4FullAttentionSpec(FullAttentionSpec):
 # ---------------------------------------------------------------------------
 
 
+class TQ4MetadataBuilder(FlashAttentionMetadataBuilder):
+    """Metadata builder for TQ4 with single-token-decode CUDA graph support.
+
+    TQ4 only supports CUDA graphs for single-token decode (the prefill
+    path has dynamic allocations).  Inherits all metadata-building logic
+    from Flash Attention; only the CUDA graph support level differs.
+    """
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: object,
+        kv_cache_spec: object,
+    ) -> AttentionCGSupport:
+        """Report single-token-decode CUDA graph support (D7 mod 3)."""
+        from vllm.v1.attention.backend import AttentionCGSupport
+
+        return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+
+
 class TQ4AttentionBackend(FlashAttentionBackend):
     """TQ4 compressed KV cache attention backend.
 
@@ -127,8 +151,8 @@ class TQ4AttentionBackend(FlashAttentionBackend):
 
     @staticmethod
     def get_builder_cls() -> type[AttentionMetadataBuilder]:
-        """Return :class:`FlashAttentionMetadataBuilder` -- reused."""
-        return FlashAttentionMetadataBuilder
+        """Return :class:`TQ4MetadataBuilder` for CUDA graph support."""
+        return TQ4MetadataBuilder
 
     @staticmethod
     def get_kv_cache_shape(
@@ -189,14 +213,26 @@ class TQ4AttentionImpl(FlashAttentionImpl):
 
         # TQ4 compression primitives (deterministic from seed, shared across layers)
         quantizer = TurboQuantMSE(head_size, TQ4_BITS, seed=TQ4_SEED)
-        self._tq4_rotation = quantizer.rotation  # (D, D) fp32
-        self._tq4_centroids = quantizer.codebook.centroids  # (16,) fp32
-        self._tq4_boundaries = quantizer.codebook.boundaries  # (15,) fp32
+
+        # Eagerly move primitives to the target device (D7 mod 5).
+        # FlashAttentionImpl.__init__ doesn't expose device, but
+        # vLLM's global config is available during model construction.
+        from vllm.config import get_current_vllm_config_or_none
+
+        vllm_config = get_current_vllm_config_or_none()
+        device = (
+            vllm_config.device_config.device
+            if vllm_config is not None
+            else torch.device("cpu")
+        )
+
+        self._tq4_rotation = quantizer.rotation.to(device)  # (D, D) fp32
+        self._tq4_centroids = quantizer.codebook.centroids.to(device)  # (16,) fp32
+        self._tq4_boundaries = quantizer.codebook.boundaries.to(device)  # (15,) fp32
         # Pre-split rotation.T for fused compress kernel (contiguous loads)
         rot_t = quantizer.rotation.T.contiguous()
-        self._tq4_rot_T_even = rot_t[:, 0::2].contiguous()  # (D, D//2) fp32
-        self._tq4_rot_T_odd = rot_t[:, 1::2].contiguous()  # (D, D//2) fp32
-        self._tq4_on_device = False
+        self._tq4_rot_T_even = rot_t[:, 0::2].contiguous().to(device)  # (D, D//2) fp32
+        self._tq4_rot_T_odd = rot_t[:, 1::2].contiguous().to(device)  # (D, D//2) fp32
 
         # Byte layout offsets within the last dimension of the packed cache.
         # Layout: [K_indices(H*D/2) | K_norms(H*4) | V_indices(H*D/2) | V_norms(H*4)]
@@ -207,6 +243,11 @@ class TQ4AttentionImpl(FlashAttentionImpl):
         self._v_idx_end = self._k_norm_end + num_kv_heads * half_D
         self._total_bytes = self._v_idx_end + num_kv_heads * TQ4_NORM_BYTES
 
+        # CUDA graph scratch buffers (D7 mod 2) — lazy-allocated on first
+        # forward() from kv_cache.shape, which is stable for engine lifetime.
+        # First forward runs during vLLM warmup, before graph capture.
+        self._cg_buffers_ready = False
+
         logger.info(
             "TQ4AttentionImpl: %d KV heads, head_size=%d, "
             "%d bytes/token (%.2fx compression vs FP16)",
@@ -216,69 +257,64 @@ class TQ4AttentionImpl(FlashAttentionImpl):
             (2 * num_kv_heads * head_size * 2) / self._total_bytes,
         )
 
-    # ----- device management -----
+    def _init_cg_buffers(
+        self, kv_cache: torch.Tensor, compute_dtype: torch.dtype
+    ) -> None:
+        """Pre-allocate CUDA graph scratch buffers from kv_cache shape.
 
-    def _ensure_device(self, device: torch.device) -> None:
-        """Move compression primitives to GPU on first use."""
-        if not self._tq4_on_device:
-            self._tq4_rotation = self._tq4_rotation.to(device)
-            self._tq4_centroids = self._tq4_centroids.to(device)
-            self._tq4_boundaries = self._tq4_boundaries.to(device)
-            self._tq4_rot_T_even = self._tq4_rot_T_even.to(device)
-            self._tq4_rot_T_odd = self._tq4_rot_T_odd.to(device)
-            self._tq4_on_device = True
-
-    # ----- compression / decompression -----
-
-    def _compress(
-        self,
-        x: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Compress ``(N, H, D)`` -> nibble-packed indices + fp32 norms.
-
-        Uses the fused Triton kernel (Phase 3c.9) that performs norm +
-        normalize + rotation + bucketize + pack in a single launch.
-
-        Returns:
-            packed: ``(N, H, D//2)`` uint8 -- two 4-bit centroid indices per byte.
-            norms: ``(N, H, 1)`` fp32 -- vector norms.
-        """
-        return tq4_compress(
-            x,
-            self._tq4_rot_T_even,
-            self._tq4_rot_T_odd,
-            self._tq4_boundaries,
-        )
-
-    def _decompress(
-        self,
-        packed: torch.Tensor,
-        norms: torch.Tensor,
-        dtype: torch.dtype,
-    ) -> torch.Tensor:
-        """Decompress nibble-packed indices + norms -> ``(N, H, D)``.
+        Called once during vLLM warmup (first forward), before CUDA graph
+        capture.  Uses max-size + slicing (D7 pattern), NOT per-batch
+        allocations.
 
         Args:
-            packed: ``(N, H, D//2)`` uint8.
-            norms: ``(N, H, 1)`` fp32.
-            dtype: Output dtype (e.g., ``torch.bfloat16``).
-
-        Returns:
-            Reconstructed tensor ``(N, H, D)`` in ``dtype``.
+            kv_cache: ``(num_blocks, block_size, total_bytes)`` uint8 cache.
+            compute_dtype: Model compute dtype (e.g. ``torch.bfloat16``).
         """
-        N, H, half_D = packed.shape
-        D = half_D * 2
+        num_blocks, block_size, _ = kv_cache.shape
+        max_tokens = num_blocks * block_size
+        device = kv_cache.device
+        H = self.num_kv_heads
+        D = self.head_size
 
-        high = (packed >> 4).long()
-        low = (packed & 0x0F).long()
-        indices = torch.stack([high, low], dim=-1).reshape(N * H, D)
+        # Decompress buffers: full cache decompressed to compute dtype
+        self._cg_decompress_k = torch.empty(
+            max_tokens, H, D, dtype=compute_dtype, device=device
+        )
+        self._cg_decompress_v = torch.empty_like(self._cg_decompress_k)
 
-        flat_norms = norms.reshape(N * H, 1)
-        reconstructed = self._tq4_centroids[indices]
-        unrotated = reconstructed @ self._tq4_rotation
-        result = unrotated * flat_norms
+        # Compress output buffers for one decode step (single token)
+        half_D = self._half_D
+        self._cg_compress_packed = torch.empty(
+            1, H, half_D, dtype=torch.uint8, device=device
+        )
+        self._cg_compress_norms = torch.empty(
+            1, H, 1, dtype=torch.float32, device=device
+        )
 
-        return result.reshape(N, H, D).to(dtype)
+        # Q rotation buffer for decode (single token, fp32 for precision)
+        self._cg_q_rot = torch.empty(
+            1, self.num_heads, D, dtype=torch.float32, device=device
+        )
+
+        # Q rotation cast buffer (compute dtype for Flash Attention input)
+        self._cg_q_rot_cast = torch.empty(
+            1, self.num_heads, D, dtype=compute_dtype, device=device
+        )
+
+        # Compress row assembly buffer for _compress_and_store
+        self._cg_compress_row = torch.empty(
+            1, self._total_bytes, dtype=torch.uint8, device=device
+        )
+
+        self._cg_buffers_ready = True
+        dtype_bytes = self._cg_decompress_k.element_size()
+        logger.info(
+            "TQ4 CUDA graph buffers allocated: max_tokens=%d, "
+            "decompress=2×%.1f MiB, compress+row+q_rot=%.1f KiB",
+            max_tokens,
+            max_tokens * H * D * dtype_bytes / (1024 * 1024),
+            (half_D * H + 4 * H + self.num_heads * D * 4 + self._total_bytes) / 1024,
+        )
 
     # ----- packed cache operations (3c.4 - 3c.5) -----
 
@@ -288,6 +324,9 @@ class TQ4AttentionImpl(FlashAttentionImpl):
         value: torch.Tensor,
         kv_cache: torch.Tensor,
         slot_mapping: torch.Tensor,
+        *,
+        compress_out: tuple[torch.Tensor, torch.Tensor] | None = None,
+        row_out: torch.Tensor | None = None,
     ) -> None:
         """Compress K/V and scatter-write TQ4 bytes to packed cache.
 
@@ -296,19 +335,41 @@ class TQ4AttentionImpl(FlashAttentionImpl):
             value: ``(N, H, D)`` new value tokens.
             kv_cache: ``(NB, BS, total_bytes)`` uint8 packed cache.
             slot_mapping: ``(num_actual_tokens,)`` flat slot indices.
+            compress_out: Optional pre-allocated ``(packed, norms)`` buffers
+                for tq4_compress (D7 CUDA graph decode path).
+            row_out: Optional pre-allocated row assembly buffer ``(N, total_bytes)``
+                uint8 (D7 CUDA graph decode path).
         """
-        k_packed, k_norms = self._compress(key)  # (N, H, D//2), (N, H, 1)
-        v_packed, v_norms = self._compress(value)
-
-        N = k_packed.shape[0]
+        N = key.shape[0]
         H = self.num_kv_heads
-        device = key.device
 
         # Build packed byte row per token: [K_idx | K_norm | V_idx | V_norm]
-        row = torch.empty(N, self._total_bytes, dtype=torch.uint8, device=device)
+        # When compress_out is shared between K and V, we must copy K's
+        # result into the row before V overwrites the shared buffer.
+        row = (
+            row_out[:N]
+            if row_out is not None
+            else torch.empty(N, self._total_bytes, dtype=torch.uint8, device=key.device)
+        )
+
+        k_packed, k_norms = tq4_compress(
+            key,
+            self._tq4_rot_T_even,
+            self._tq4_rot_T_odd,
+            self._tq4_boundaries,
+            out=compress_out,
+        )
         row[:, : self._k_idx_end] = k_packed.reshape(N, -1)
         row[:, self._k_idx_end : self._k_norm_end] = (
             k_norms.reshape(N, H).contiguous().view(torch.uint8)
+        )
+
+        v_packed, v_norms = tq4_compress(
+            value,
+            self._tq4_rot_T_even,
+            self._tq4_rot_T_odd,
+            self._tq4_boundaries,
+            out=compress_out,
         )
         row[:, self._k_norm_end : self._v_idx_end] = v_packed.reshape(N, -1)
         row[:, self._v_idx_end :] = v_norms.reshape(N, H).contiguous().view(torch.uint8)
@@ -324,6 +385,8 @@ class TQ4AttentionImpl(FlashAttentionImpl):
         compute_dtype: torch.dtype,
         *,
         apply_rotation: bool = True,
+        out_k: torch.Tensor | None = None,
+        out_v: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Decompress packed uint8 cache -> key_cache, value_cache.
 
@@ -339,6 +402,10 @@ class TQ4AttentionImpl(FlashAttentionImpl):
             apply_rotation: If ``True`` (default), apply unrotation to
                 return tensors in original space.  ``False`` returns
                 rotated-space tensors for the optimized forward path.
+            out_k: Optional pre-allocated ``(max_tokens, H, D)`` buffer for
+                decompressed keys (D7 CUDA graph decode path).
+            out_v: Optional pre-allocated ``(max_tokens, H, D)`` buffer for
+                decompressed values (D7 CUDA graph decode path).
 
         Returns:
             key_cache: ``(NB, BS, H, D)`` in ``compute_dtype``.
@@ -349,7 +416,6 @@ class TQ4AttentionImpl(FlashAttentionImpl):
         half_D = self._half_D
         D = self.head_size
 
-        self._ensure_device(kv_cache.device)
         flat = kv_cache.reshape(NB * BS, self._total_bytes)
 
         # Extract K regions
@@ -375,12 +441,11 @@ class TQ4AttentionImpl(FlashAttentionImpl):
         )
 
         # Fused Triton decompress (no rotation applied)
-        key_out = tq4_decompress(k_packed, k_norms, self._tq4_centroids, compute_dtype)
+        key_out = tq4_decompress(
+            k_packed, k_norms, self._tq4_centroids, compute_dtype, out=out_k
+        )
         value_out = tq4_decompress(
-            v_packed,
-            v_norms,
-            self._tq4_centroids,
-            compute_dtype,
+            v_packed, v_norms, self._tq4_centroids, compute_dtype, out=out_v
         )
 
         # Optionally unrotate (backward compat for tests; forward() skips this)
@@ -389,6 +454,54 @@ class TQ4AttentionImpl(FlashAttentionImpl):
             value_out = (value_out.float() @ self._tq4_rotation).to(compute_dtype)
 
         return key_out.reshape(NB, BS, H, D), value_out.reshape(NB, BS, H, D)
+
+    # ----- TQ4 encode / decode helpers -----
+
+    def _tq4_decode(
+        self, query, key, value, kv_cache, attn_metadata
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Decode path: compress, rotate Q, decompress using pre-allocated buffers."""
+        if key is not None and value is not None:
+            self._compress_and_store(
+                key,
+                value,
+                kv_cache,
+                attn_metadata.slot_mapping,
+                compress_out=(self._cg_compress_packed, self._cg_compress_norms),
+                row_out=self._cg_compress_row,
+            )
+
+        q_slice = query[: attn_metadata.num_actual_tokens]
+        q_rot_buf = self._cg_q_rot[:1]
+        torch.matmul(q_slice.float(), self._tq4_rotation.T, out=q_rot_buf)
+        self._cg_q_rot_cast[:1].copy_(q_rot_buf)
+
+        key_cache, value_cache = self._decompress_cache(
+            kv_cache,
+            query.dtype,
+            apply_rotation=False,
+            out_k=self._cg_decompress_k,
+            out_v=self._cg_decompress_v,
+        )
+        return self._cg_q_rot_cast[:1], key_cache, value_cache
+
+    def _tq4_prefill(
+        self, query, key, value, kv_cache, attn_metadata
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Prefill path: compress, rotate Q, decompress with dynamic allocation."""
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        if kv_cache is not None and key is not None and value is not None:
+            self._compress_and_store(key, value, kv_cache, attn_metadata.slot_mapping)
+
+        q_slice = query[:num_actual_tokens]
+        q_rot = (q_slice.float() @ self._tq4_rotation.T).to(q_slice.dtype)
+
+        key_cache, value_cache = self._decompress_cache(
+            kv_cache,
+            query.dtype,
+            apply_rotation=False,
+        )
+        return q_rot, key_cache, value_cache
 
     # ----- forward -----
 
@@ -438,22 +551,20 @@ class TQ4AttentionImpl(FlashAttentionImpl):
 
         num_actual_tokens = attn_metadata.num_actual_tokens
 
-        # Step 1: Compress and store new K/V tokens
-        if kv_cache is not None and key is not None and value is not None:
-            self._ensure_device(query.device)
-            self._compress_and_store(key, value, kv_cache, attn_metadata.slot_mapping)
+        # Lazy-init CUDA graph buffers on first forward (during warmup)
+        if not self._cg_buffers_ready and kv_cache is not None:
+            self._init_cg_buffers(kv_cache, compute_dtype=query.dtype)
 
-        # Step 2: Pre-rotate Q by Pi^T (O(num_actual_tokens), not O(cache_len))
-        self._ensure_device(query.device)
-        q_slice = query[:num_actual_tokens]
-        q_rot = (q_slice.float() @ self._tq4_rotation.T).to(q_slice.dtype)
-
-        # Step 3: Decompress full cache (Triton fused, skip rotation)
-        key_cache, value_cache = self._decompress_cache(
-            kv_cache,
-            query.dtype,
-            apply_rotation=False,
-        )
+        # Steps 1-3: compress, rotate Q, decompress (decode vs prefill path)
+        is_decode = self._cg_buffers_ready and num_actual_tokens == 1
+        if is_decode:
+            q_rot, key_cache, value_cache = self._tq4_decode(
+                query, key, value, kv_cache, attn_metadata
+            )
+        else:
+            q_rot, key_cache, value_cache = self._tq4_prefill(
+                query, key, value, kv_cache, attn_metadata
+            )
 
         # Step 4: Run Flash Attention with rotated Q and rotated KV
         from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func

--- a/tests/test_vllm_cache.py
+++ b/tests/test_vllm_cache.py
@@ -17,6 +17,7 @@ from turboquant_vllm.vllm.tq4_backend import (  # noqa: E402  # isort: skip
     TQ4AttentionBackend,
     TQ4AttentionImpl,
     TQ4FullAttentionSpec,
+    TQ4MetadataBuilder,
     _tq4_bytes_per_token,
     _tq4_bytes_per_token_kv,
 )
@@ -131,6 +132,7 @@ class TestTQ4PackedCacheRoundTrip:
     """Compress -> store -> decompress round-trip on packed uint8 cache."""
 
     NUM_KV_HEADS = 8
+    NUM_HEADS = 32  # GQA: 4:1 Q-to-KV ratio (matches Molmo2-8B)
     HEAD_SIZE = 128
     BLOCK_SIZE = 16
 
@@ -146,6 +148,7 @@ class TestTQ4PackedCacheRoundTrip:
         impl = object.__new__(TQ4AttentionImpl)
         impl.head_size = self.HEAD_SIZE
         impl.num_kv_heads = self.NUM_KV_HEADS
+        impl.num_heads = self.NUM_HEADS
 
         impl._tq4_rotation = quantizer.rotation.clone()
         impl._tq4_centroids = quantizer.codebook.centroids.clone()
@@ -153,7 +156,7 @@ class TestTQ4PackedCacheRoundTrip:
         rot_t = quantizer.rotation.T.contiguous()
         impl._tq4_rot_T_even = rot_t[:, 0::2].contiguous()
         impl._tq4_rot_T_odd = rot_t[:, 1::2].contiguous()
-        impl._tq4_on_device = False
+        impl._cg_buffers_ready = False
 
         half_D = self.HEAD_SIZE // 2
         impl._half_D = half_D
@@ -337,3 +340,312 @@ class TestTQ4PackedCacheRoundTrip:
         key_cache, value_cache = impl._decompress_cache(kv_cache, torch.bfloat16)
         assert key_cache.dtype == torch.bfloat16
         assert value_cache.dtype == torch.bfloat16
+
+    def test_no_ensure_device_flag(self, tq4_quantizer) -> None:
+        """Eager device init removed _tq4_on_device flag (D7 mod 5)."""
+        impl = self._make_impl(tq4_quantizer)
+        assert not hasattr(impl, "_tq4_on_device")
+        assert not hasattr(impl, "_ensure_device")
+
+
+# ---------------------------------------------------------------------------
+# D7: CUDA graph buffer pre-allocation tests
+# ---------------------------------------------------------------------------
+
+
+class TestCUDAGraphBufferPreallocation:
+    """Tests for D7 CUDA graph buffer pre-allocation."""
+
+    NUM_KV_HEADS = 8
+    NUM_HEADS = 32
+    HEAD_SIZE = 128
+    BLOCK_SIZE = 16
+
+    def _make_impl(self, quantizer):
+        """Create a TQ4AttentionImpl without full vLLM init."""
+        from turboquant_vllm.vllm.tq4_backend import TQ4_NORM_BYTES
+
+        impl = object.__new__(TQ4AttentionImpl)
+        impl.head_size = self.HEAD_SIZE
+        impl.num_kv_heads = self.NUM_KV_HEADS
+        impl.num_heads = self.NUM_HEADS
+
+        impl._tq4_rotation = quantizer.rotation.clone()
+        impl._tq4_centroids = quantizer.codebook.centroids.clone()
+        impl._tq4_boundaries = quantizer.codebook.boundaries.clone()
+        rot_t = quantizer.rotation.T.contiguous()
+        impl._tq4_rot_T_even = rot_t[:, 0::2].contiguous()
+        impl._tq4_rot_T_odd = rot_t[:, 1::2].contiguous()
+        impl._cg_buffers_ready = False
+
+        half_D = self.HEAD_SIZE // 2
+        impl._half_D = half_D
+        impl._k_idx_end = self.NUM_KV_HEADS * half_D
+        impl._k_norm_end = impl._k_idx_end + self.NUM_KV_HEADS * TQ4_NORM_BYTES
+        impl._v_idx_end = impl._k_norm_end + self.NUM_KV_HEADS * half_D
+        impl._total_bytes = impl._v_idx_end + self.NUM_KV_HEADS * TQ4_NORM_BYTES
+
+        return impl
+
+    def _make_cache(self, num_blocks):
+        total_bytes = self.NUM_KV_HEADS * _tq4_bytes_per_token_kv(self.HEAD_SIZE)
+        return torch.zeros(num_blocks, self.BLOCK_SIZE, total_bytes, dtype=torch.uint8)
+
+    def test_get_cudagraph_support_returns_single_token_decode(self) -> None:
+        """TQ4 builder reports UNIFORM_SINGLE_TOKEN_DECODE (AC 2)."""
+        from vllm.v1.attention.backend import AttentionCGSupport
+
+        result = TQ4MetadataBuilder.get_cudagraph_support(None, None)
+        assert result == AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+
+    def test_backend_returns_tq4_builder(self) -> None:
+        """TQ4AttentionBackend.get_builder_cls() returns TQ4MetadataBuilder."""
+        assert TQ4AttentionBackend.get_builder_cls() is TQ4MetadataBuilder
+
+    def test_init_cg_buffers_shapes(self, tq4_quantizer) -> None:
+        """_init_cg_buffers creates buffers of correct shape/dtype (AC 1)."""
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=4)
+
+        assert not impl._cg_buffers_ready
+        impl._init_cg_buffers(kv_cache, compute_dtype=torch.float16)
+        assert impl._cg_buffers_ready
+
+        max_tokens = 4 * self.BLOCK_SIZE  # 64
+        H = self.NUM_KV_HEADS
+        D = self.HEAD_SIZE
+
+        assert impl._cg_decompress_k.shape == (max_tokens, H, D)
+        assert impl._cg_decompress_k.dtype == torch.float16
+        assert impl._cg_decompress_v.shape == (max_tokens, H, D)
+        assert impl._cg_decompress_v.dtype == torch.float16
+
+        assert impl._cg_compress_packed.shape == (1, H, D // 2)
+        assert impl._cg_compress_packed.dtype == torch.uint8
+        assert impl._cg_compress_norms.shape == (1, H, 1)
+        assert impl._cg_compress_norms.dtype == torch.float32
+
+        assert impl._cg_q_rot.shape == (1, self.NUM_HEADS, D)
+        assert impl._cg_q_rot.dtype == torch.float32
+        assert impl._cg_q_rot_cast.shape == (1, self.NUM_HEADS, D)
+        assert impl._cg_q_rot_cast.dtype == torch.float16
+
+        assert impl._cg_compress_row.shape == (1, impl._total_bytes)
+        assert impl._cg_compress_row.dtype == torch.uint8
+
+    def test_preallocated_decompress_matches_dynamic(self, tq4_quantizer) -> None:
+        """Blocking acceptance test: pre-allocated buffers match dynamic (AC 4).
+
+        Uses float16 (matching pre-allocated buffer dtype and real forward path).
+        """
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=4)
+
+        # Write some tokens
+        key = torch.randn(3, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        value = torch.randn(3, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        slot_mapping = torch.tensor([0, 5, 33])
+        impl._compress_and_store(key, value, kv_cache, slot_mapping)
+
+        # Dynamic allocation (no out= buffers)
+        k_dynamic, v_dynamic = impl._decompress_cache(
+            kv_cache, torch.float16, apply_rotation=False
+        )
+
+        # Pre-allocated buffers (max-size, sliced by decompress)
+        impl._init_cg_buffers(kv_cache, compute_dtype=torch.float16)
+        k_prealloc, v_prealloc = impl._decompress_cache(
+            kv_cache,
+            torch.float16,
+            apply_rotation=False,
+            out_k=impl._cg_decompress_k,
+            out_v=impl._cg_decompress_v,
+        )
+
+        # Must be IDENTICAL (not just close)
+        assert torch.equal(k_dynamic, k_prealloc), (
+            "Pre-allocated K decompress differs from dynamic"
+        )
+        assert torch.equal(v_dynamic, v_prealloc), (
+            "Pre-allocated V decompress differs from dynamic"
+        )
+
+    def test_preallocated_decompress_bfloat16(self, tq4_quantizer) -> None:
+        """Decompress buffers use compute_dtype, not hardcoded float16 (F2)."""
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=4)
+
+        key = torch.randn(3, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        value = torch.randn(3, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        impl._compress_and_store(key, value, kv_cache, torch.tensor([0, 5, 33]))
+
+        # Dynamic path with bfloat16
+        k_dynamic, v_dynamic = impl._decompress_cache(
+            kv_cache, torch.bfloat16, apply_rotation=False
+        )
+        assert k_dynamic.dtype == torch.bfloat16
+
+        # Pre-allocated path with bfloat16 compute_dtype
+        impl._init_cg_buffers(kv_cache, compute_dtype=torch.bfloat16)
+        assert impl._cg_decompress_k.dtype == torch.bfloat16
+
+        k_prealloc, v_prealloc = impl._decompress_cache(
+            kv_cache,
+            torch.bfloat16,
+            apply_rotation=False,
+            out_k=impl._cg_decompress_k,
+            out_v=impl._cg_decompress_v,
+        )
+        assert k_prealloc.dtype == torch.bfloat16
+        assert torch.equal(k_dynamic, k_prealloc), (
+            "BF16 pre-allocated K differs from dynamic"
+        )
+        assert torch.equal(v_dynamic, v_prealloc), (
+            "BF16 pre-allocated V differs from dynamic"
+        )
+
+    def test_decode_path_uses_preallocated_compress(self, tq4_quantizer) -> None:
+        """Decode compress uses pre-allocated buffers (AC 3)."""
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=2)
+        impl._init_cg_buffers(kv_cache, compute_dtype=torch.float16)
+
+        key = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        value = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        slot_mapping = torch.tensor([0])
+
+        # Compress with pre-allocated buffers
+        impl._compress_and_store(
+            key,
+            value,
+            kv_cache,
+            slot_mapping,
+            compress_out=(impl._cg_compress_packed, impl._cg_compress_norms),
+            row_out=impl._cg_compress_row,
+        )
+
+        # Verify data was written to cache
+        flat = kv_cache.view(-1, impl._total_bytes)
+        assert flat[0].any(), "Slot 0 should have data after pre-allocated compress"
+
+        # Decompress and verify round-trip
+        k_cache, v_cache = impl._decompress_cache(kv_cache, torch.float32)
+        recon_k = k_cache.view(-1, self.NUM_KV_HEADS, self.HEAD_SIZE)[0]
+        for h in range(self.NUM_KV_HEADS):
+            cos_k = torch.nn.functional.cosine_similarity(
+                key[0, h].unsqueeze(0), recon_k[h].unsqueeze(0)
+            ).item()
+            assert cos_k > 0.85, f"Pre-alloc compress K head {h} cosine {cos_k:.4f}"
+
+    def test_prefill_path_unchanged(self, tq4_quantizer) -> None:
+        """Prefill (multi-token) path still uses dynamic allocation (AC 5)."""
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=4)
+
+        N = 5
+        key = torch.randn(N, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        value = torch.randn(N, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        slot_mapping = torch.tensor([0, 1, 2, 3, 4])
+
+        # Without pre-allocated buffers (prefill path)
+        impl._compress_and_store(key, value, kv_cache, slot_mapping)
+        k_cache, _ = impl._decompress_cache(kv_cache, torch.float32)
+        flat_k = k_cache.view(-1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+
+        for i in range(N):
+            for h in range(self.NUM_KV_HEADS):
+                cos = torch.nn.functional.cosine_similarity(
+                    key[i, h].unsqueeze(0), flat_k[i, h].unsqueeze(0)
+                ).item()
+                assert cos > 0.85, f"Prefill token {i} head {h} cosine {cos:.4f}"
+
+    def test_buffer_reuse_consecutive_decode_steps(self, tq4_quantizer) -> None:
+        """Same buffers reused on consecutive decode steps (AC 3)."""
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=2)
+        impl._init_cg_buffers(kv_cache, compute_dtype=torch.float16)
+
+        compress_out = (impl._cg_compress_packed, impl._cg_compress_norms)
+        row_out = impl._cg_compress_row
+
+        # Step 1
+        key1 = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        val1 = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        impl._compress_and_store(
+            key1,
+            val1,
+            kv_cache,
+            torch.tensor([0]),
+            compress_out=compress_out,
+            row_out=row_out,
+        )
+
+        # Step 2 (same buffers, different slot)
+        key2 = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        val2 = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        impl._compress_and_store(
+            key2,
+            val2,
+            kv_cache,
+            torch.tensor([1]),
+            compress_out=compress_out,
+            row_out=row_out,
+        )
+
+        # Both slots should have data
+        flat = kv_cache.view(-1, impl._total_bytes)
+        assert flat[0].any(), "Slot 0 should have data"
+        assert flat[1].any(), "Slot 1 should have data"
+
+        # Verify each slot decompresses correctly
+        k_cache, _ = impl._decompress_cache(kv_cache, torch.float32)
+        flat_k = k_cache.view(-1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        cos_1 = torch.nn.functional.cosine_similarity(
+            key1[0, 0].unsqueeze(0), flat_k[0, 0].unsqueeze(0)
+        ).item()
+        cos_2 = torch.nn.functional.cosine_similarity(
+            key2[0, 0].unsqueeze(0), flat_k[1, 0].unsqueeze(0)
+        ).item()
+        assert cos_1 > 0.85, f"Step 1 cosine {cos_1:.4f}"
+        assert cos_2 > 0.85, f"Step 2 cosine {cos_2:.4f}"
+
+    def test_stale_data_immunity(self, tq4_quantizer) -> None:
+        """Stale data in decompress buffers doesn't affect output (AC 4).
+
+        Fill decompress buffers with garbage before calling decompress+
+        flash_attn. Validates that tq4_decompress overwrites all positions
+        and that stale data in unused positions doesn't leak.
+        """
+        impl = self._make_impl(tq4_quantizer)
+        kv_cache = self._make_cache(num_blocks=4)
+        impl._init_cg_buffers(kv_cache, compute_dtype=torch.float16)
+
+        # Write some data
+        key = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        value = torch.randn(1, self.NUM_KV_HEADS, self.HEAD_SIZE)
+        impl._compress_and_store(key, value, kv_cache, torch.tensor([5]))
+
+        # Fill decompress buffers with garbage
+        impl._cg_decompress_k.fill_(99.0)
+        impl._cg_decompress_v.fill_(99.0)
+
+        # Decompress into garbage-filled buffers
+        k_stale, _ = impl._decompress_cache(
+            kv_cache,
+            torch.float16,
+            apply_rotation=False,
+            out_k=impl._cg_decompress_k,
+            out_v=impl._cg_decompress_v,
+        )
+
+        # Clean run (fresh buffers)
+        k_clean, _ = impl._decompress_cache(
+            kv_cache, torch.float16, apply_rotation=False
+        )
+
+        # The written slot (5) must be identical regardless of stale data
+        stale_k5 = k_stale.view(-1, self.NUM_KV_HEADS, self.HEAD_SIZE)[5]
+        clean_k5 = k_clean.view(-1, self.NUM_KV_HEADS, self.HEAD_SIZE)[5]
+        assert torch.equal(stale_k5, clean_k5), (
+            "Stale data in decompress buffer affected written slot output"
+        )

--- a/tests/test_vllm_registration.py
+++ b/tests/test_vllm_registration.py
@@ -88,7 +88,10 @@ class TestTQ4AttentionBackend:
         assert TQ4AttentionBackend.get_impl_cls() is TQ4AttentionImpl
 
     def test_builder_cls(self) -> None:
-        assert TQ4AttentionBackend.get_builder_cls() is FlashAttentionMetadataBuilder
+        from turboquant_vllm.vllm.tq4_backend import TQ4MetadataBuilder
+
+        assert TQ4AttentionBackend.get_builder_cls() is TQ4MetadataBuilder
+        assert issubclass(TQ4MetadataBuilder, FlashAttentionMetadataBuilder)
 
     def test_subclasses_flash_attention(self) -> None:
         assert issubclass(TQ4AttentionBackend, FlashAttentionBackend)


### PR DESCRIPTION
The TQ4 backend previously allocated temporary tensors on every forward()
call for decompress, compress, Q rotation, and row assembly. These dynamic
allocations broke CUDA graph capture for the decode path. This change
pre-allocates max-size scratch buffers on first forward (during vLLM warmup)
and uses them via the out parameter added in Story 4.1.

- Add TQ4MetadataBuilder reporting UNIFORM_SINGLE_TOKEN_DECODE support
- Pre-allocate 6 scratch buffers from kv_cache.shape on first forward
- Split decode/prefill into _tq4_decode/_tq4_prefill helpers (CC 18→clean)
- Eager device init via vllm_config, remove lazy _ensure_device
- Fix decompress buffer dtype to use compute_dtype (was hardcoded fp16)
- Fix q_rot cast to use pre-allocated buffer (was dynamic .to() call)
- Remove dead _compress/_decompress methods (-50 lines, 704→673)
- Add 10 new tests including bfloat16 regression and stale data immunity

Test: `uv run pytest -m "not gpu" -x`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`) — 181 CPU tests, 96.50% coverage
- [x] Lint passes (`uv run ruff check .`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- F2 fix: decompress buffers now use compute_dtype parameter — verify bfloat16 test exercises the Triton kernel dtype path (CPU fallback uses dtype arg correctly; GPU kernel uses Out.dtype.element_ty)
- _tq4_decode helper: verify the pre-allocated buffer wiring matches forward()'s original logic
- Module is 673 lines (over 500-line gate) — flagged for post-Epic-4 split

### Related
- Story 4.1 (compress/decompress out parameter): merged as commit 6fc60d8
- Architecture D7: CUDA graph compatibility (6 modifications, this implements mods 2-6)
- D9.6 transitional note: decompress buffers are transitional, fused kernel eliminates them